### PR TITLE
[Fix] Add noEase type to EaseTweenCombinationType

### DIFF
--- a/types/AnimationTypes.ts
+++ b/types/AnimationTypes.ts
@@ -33,7 +33,7 @@ export enum TweenTypes {
     back = 'Back',
 }
 
-export type EaseTweenCombinationType = `${EaseTypes}${TweenTypes}`;
+export type EaseTweenCombinationType = `${EaseTypes}${TweenTypes}` | 'noEase';
 
 export type BasicAnimationsIntroOutroStylesType = {
     slide?: {


### PR DESCRIPTION
This PR adds the noEase option to the EaseTweenCombinationType.

## Related tickets

-   [WRS-177](https://support.chili-publish.com/projects/WRS/issues/WRS-177)