### PR TITLE
[Fix] Animation typings slideDirection and typo

### DIFF
--- a/types/AnimationTypes.ts
+++ b/types/AnimationTypes.ts
@@ -37,8 +37,7 @@ export type EaseTweenCombinationType = `${EaseTypes}${TweenTypes}` | 'noEase';
 
 export type BasicAnimationsIntroOutroStylesType = {
     slide?: {
-        slideFrom?: SlideDirections;
-        slideTo?: SlideDirections;
+        slideDirection: SlideDirections;
         offsetPercent: number;
     };
     rotation?: {
@@ -73,7 +72,7 @@ export type BasicAnimationsMiddleType = {
         headShake?: boolean;
         swing?: boolean;
         tada?: boolean;
-        heartBeat?: boolean;
+        heartbeat?: boolean;
     };
 };
 


### PR DESCRIPTION
This PR fixes a typo on heartbeat and changes slideFrom / to into slideDirection to make it more genereic
