### PR TITLE
[Fix] Continue PR build on publish fail

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,6 +34,7 @@ jobs:
             - name: run tests
               run: yarn cover
             - name: Publish Unit Test Results
+              continue-on-error: true
               uses: EnricoMi/publish-unit-test-result-action@v1
               if: always()
               with:


### PR DESCRIPTION
This PR will maybe fix the issue that dependabot can't trigger builds correctly