### PR TITLE
[Fix] Update connector type

### DIFF
--- a/src/types/FrameTypes.ts
+++ b/src/types/FrameTypes.ts
@@ -120,7 +120,7 @@ export type NoCropSettings = {
 export enum ImageSourceTypeEnum {
     url = 'url',
     variable = 'variable',
-    connector = 'assetProvider',
+    connector = 'connector',
 }
 
 export enum FrameTypeEnum {

--- a/types/Actions.d.ts
+++ b/types/Actions.d.ts
@@ -64,7 +64,7 @@ declare module 'grafx-studio-actions' {
 
     enum VariableSourceType {
         url = 'url',
-        mediaConnector = 'mediaConnector',
+        connector = 'connector',
     }
 
     interface UrlVariableSource {
@@ -75,7 +75,7 @@ declare module 'grafx-studio-actions' {
     interface MediaConnectorVariableSource {
         connectorId: string;
         assetId: string;
-        sourceType: VariableSourceType.mediaConnector;
+        sourceType: VariableSourceType.connector;
     }
 
     type VariableSource = UrlVariableSource | MediaConnectorVariableSource;


### PR DESCRIPTION
This PR 
- renames the connector type from `assetProvider` to `connector` on Frame Types. 
- renames the connector type from `mediaConnector` to `connector` in Action Types. 
