### PR TITLE
Add remaining SDK methods for Actions

### DIFF
--- a/src/controllers/ActionController.ts
+++ b/src/controllers/ActionController.ts
@@ -1,4 +1,4 @@
-import { ActionTrigger } from '../types/ActionTypes';
+import { ActionTrigger, DocumentAction } from '../types/ActionTypes';
 import { EditorAPI, Id } from '../types/CommonTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 
@@ -20,12 +20,40 @@ export class ActionController {
     }
 
     /**
+     * This method returns the list of all actions.
+     * @returns
+     */
+    getActions = async () => {
+        const res = await this.#editorAPI;
+        return res.getActions().then((result) => getEditorResponseData<DocumentAction[]>(result));
+    };
+
+    /**
+     * This method returns an action by id
+     * @param actionId The ID of a specific action
+     * @returns
+     */
+    getActionById = async (actionId: Id) => {
+        const res = await this.#editorAPI;
+        return res.getActionById(actionId).then((result) => getEditorResponseData<DocumentAction>(result));
+    };
+
+    /**
      * This method creates a new action.
      * @returns The ID of the newly created action.
      */
     createAction = async () => {
         const res = await this.#editorAPI;
         return res.createAction().then((result) => getEditorResponseData<Id>(result));
+    };
+
+    /**
+     * This method duplicates an existing action.
+     * @returns The ID of the duplicated action.
+     */
+    duplicateAction = async (actionId: Id) => {
+        const res = await this.#editorAPI;
+        return res.duplicateAction(actionId).then((result) => getEditorResponseData<Id>(result));
     };
 
     /**
@@ -36,6 +64,17 @@ export class ActionController {
     removeAction = async (actionId: Id) => {
         const res = await this.#editorAPI;
         return res.removeAction(actionId).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method renames an action.
+     * @param actionId The ID of a specific action
+     * @param name The new unique name for the action
+     * @returns
+     */
+    renameAction = async (actionId: Id, name: string) => {
+        const res = await this.#editorAPI;
+        return res.renameAction(actionId, name).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/src/tests/controllers/ActionController.test.ts
+++ b/src/tests/controllers/ActionController.test.ts
@@ -6,16 +6,24 @@ import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorR
 let mockedActionController: ActionController;
 
 const mockEditorApi: EditorAPI = {
+    getActions: async () => getEditorResponseData(castToEditorResponse(null)),
+    getActionById: async () => getEditorResponseData(castToEditorResponse(null)),
     createAction: async () => getEditorResponseData(castToEditorResponse(null)),
+    duplicateAction: async () => getEditorResponseData(castToEditorResponse(null)),
     removeAction: async () => getEditorResponseData(castToEditorResponse(null)),
+    renameAction: async () => getEditorResponseData(castToEditorResponse(null)),
     updateActionScript: async () => getEditorResponseData(castToEditorResponse(null)),
     updateActionTriggers: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
     mockedActionController = new ActionController(mockEditorApi);
+    jest.spyOn(mockEditorApi, 'getActions');
+    jest.spyOn(mockEditorApi, 'getActionById');
     jest.spyOn(mockEditorApi, 'createAction');
+    jest.spyOn(mockEditorApi, 'duplicateAction');
     jest.spyOn(mockEditorApi, 'removeAction');
+    jest.spyOn(mockEditorApi, 'renameAction');
     jest.spyOn(mockEditorApi, 'updateActionScript');
     jest.spyOn(mockEditorApi, 'updateActionTriggers');
 });
@@ -29,9 +37,32 @@ afterAll(() => {
 });
 
 describe('Should call all of the ActionController functions of child successfully', () => {
+    it('Should call the getCharacterStyles method', async () => {
+        await mockedActionController.getActions();
+        expect(mockEditorApi.getActions).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should call the getCharacterStyleById method', async () => {
+        await mockedActionController.getActionById('5');
+        expect(mockEditorApi.getActionById).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.getActionById).toHaveBeenCalledWith('5');
+    });
+
     it('should call createAction function of EditorAPI with no params provided', async () => {
         await mockedActionController.createAction();
         expect(mockEditorApi.createAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call duplicateAction function of EditorAPI with the provided id', async () => {
+        await mockedActionController.duplicateAction('0');
+        expect(mockEditorApi.duplicateAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.duplicateAction).toHaveBeenCalledWith('0');
+    });
+
+    it('should call renameAction function of EditorAPI with the provided params', async () => {
+        await mockedActionController.renameAction('0', 'new name');
+        expect(mockEditorApi.renameAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.renameAction).toHaveBeenCalledWith('0', 'new name');
     });
 
     it('should call removeAction function of EditorAPI', async () => {

--- a/src/tests/controllers/ActionController.test.ts
+++ b/src/tests/controllers/ActionController.test.ts
@@ -37,12 +37,12 @@ afterAll(() => {
 });
 
 describe('Should call all of the ActionController functions of child successfully', () => {
-    it('Should call the getCharacterStyles method', async () => {
+    it('Should call the getActions method', async () => {
         await mockedActionController.getActions();
         expect(mockEditorApi.getActions).toHaveBeenCalledTimes(1);
     });
 
-    it('Should call the getCharacterStyleById method', async () => {
+    it('Should call the getActionById method', async () => {
         await mockedActionController.getActionById('5');
         expect(mockEditorApi.getActionById).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getActionById).toHaveBeenCalledWith('5');


### PR DESCRIPTION
This PR adds `getActions`, `getActionById`, `renameAction` and `duplicateAction` SDK methods.

## Related tickets

-   [EDT-723](https://support.chili-publish.com/browse/EDT-723)
