### PR TITLE
[EDT-970] enter / exit crop mode notifications

### DIFF
--- a/src/controllers/SubscriberController.ts
+++ b/src/controllers/SubscriberController.ts
@@ -1,4 +1,4 @@
-import { ConfigType } from '../types/CommonTypes';
+import { ConfigType, Id } from '../types/CommonTypes';
 import { ToolType } from '../utils/enums';
 
 /**
@@ -87,7 +87,6 @@ export class SubscriberController {
         const callBack = this.config.onDocumentLoaded;
         callBack && callBack();
     };
-
 
     /**
      * To be implemented, gets triggered when clicking on the pageTitle on the canvas.
@@ -241,5 +240,14 @@ export class SubscriberController {
     onShapeCornerRadiusChanged = (cornerRadius: string) => {
         const callBack = this.config.onShapeCornerRadiusChanged;
         callBack && callBack(JSON.parse(cornerRadius));
+    };
+
+    /**
+     * Listener of editor entering / exiting the crop mode
+     * @param id frame id when entering / null when exiting
+     */
+    onCropActiveFrameIdChanged = (id?: Id) => {
+        const callBack = this.config.onCropActiveFrameIdChanged;
+        callBack && callBack(id);
     };
 }

--- a/src/tests/controllers/SubscriberContoller.test.ts
+++ b/src/tests/controllers/SubscriberContoller.test.ts
@@ -1,4 +1,4 @@
-import { ActionEditorEvent, DocumentAction, LayoutType } from '../../index';
+import { ActionEditorEvent, DocumentAction, Id, LayoutType } from '../../index';
 import { SubscriberController } from '../../controllers/SubscriberController';
 import { mockFrameAnimation } from '../__mocks__/animations';
 
@@ -42,6 +42,7 @@ const mockEditorApi: EditorAPI = {
     onScrubberPositionChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onUndoStackStateChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onShapeCornerRadiusChanged: async () => getEditorResponseData(castToEditorResponse(null)),
+    onCropActiveFrameIdChanged: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -74,6 +75,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'onScrubberPositionChanged');
     jest.spyOn(mockEditorApi, 'onUndoStackStateChanged');
     jest.spyOn(mockEditorApi, 'onShapeCornerRadiusChanged');
+    jest.spyOn(mockEditorApi, 'onCropActiveFrameIdChanged');
 });
 
 afterEach(() => {
@@ -207,5 +209,13 @@ describe('SubscriberController', () => {
 
         expect(mockEditorApi.onShapeCornerRadiusChanged).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.onShapeCornerRadiusChanged).toHaveBeenCalledWith(cornerRadius);
+    });
+
+    it('should be possible to subscribe to onCropActiveFrameIdChanged', async () => {
+        const id: Id = '1';
+        await mockedSubscriberController.onCropActiveFrameIdChanged(id);
+
+        expect(mockEditorApi.onCropActiveFrameIdChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onCropActiveFrameIdChanged).toHaveBeenCalledWith(id);
     });
 });

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -46,6 +46,7 @@ export type ConfigType = {
     onZoomChanged?: (scaleFactor: number) => void;
     onPageSizeChanged?: (pageSize: PageSize) => void;
     onShapeCornerRadiusChanged?: (cornerRadius: CornerRadius) => void;
+    onCropActiveFrameIdChanged?: (id?: Id) => void;
 };
 
 export interface EditorResponse<T> {


### PR DESCRIPTION
This PR adds a subscription to track entering / exiting the crop mode by exposing `frameId?`

## Related tickets

-   [EDT-970](https://support.chili-publish.com/browse/EDT-970)
