### PR TITLE
[Fix] make methods show up as `method` in Action typings

### DIFF
--- a/types/Actions.d.ts
+++ b/types/Actions.d.ts
@@ -173,7 +173,7 @@ declare module 'grafx-studio-actions' {
          * @param y the frame y position
          * @returns
          */
-        move: (name: string, x: number, y: number) => void;
+        move(name: string, x: number, y: number) : void;
 
         /**
          * Resizes a frame to a specified size
@@ -182,7 +182,7 @@ declare module 'grafx-studio-actions' {
          * @param height the frame height
          * @returns
          */
-        resize: (name: string, width: number, height: number) => void;
+        resize(name: string, width: number, height: number) : void;
 
         /**
          * Moves a frame to a specified X position
@@ -190,7 +190,7 @@ declare module 'grafx-studio-actions' {
          * @param x the frame x position
          * @returns
          */
-        setX: (name: string, x: number) => void;
+        setX(name: string, x: number) : void;
 
         /**
          * Moves a frame to a specified Y position
@@ -198,7 +198,7 @@ declare module 'grafx-studio-actions' {
          * @param y the frame y position
          * @returns
          */
-        setY: (name: string, y: number) => void;
+        setY(name: string, y: number) : void;
 
         /**
          * Resizes a frame to a specified width
@@ -206,7 +206,7 @@ declare module 'grafx-studio-actions' {
          * @param width the frame width
          * @returns
          */
-        setWidth: (name: string, width: number) => void;
+        setWidth(name: string, width: number) : void;
 
         /**
          * Resizes a frame to a specified height
@@ -214,7 +214,7 @@ declare module 'grafx-studio-actions' {
          * @param height the frame height
          * @returns
          */
-        setHeight: (name: string, height: number) => void;
+        setHeight(name: string, height: number) : void;
 
         /**
          * Rotates a frame to a specified degree
@@ -222,7 +222,7 @@ declare module 'grafx-studio-actions' {
          * @param rotation the frame rotation in degrees
          * @returns
          */
-        setRotation: (name: string, rotation: number) => void;
+        setRotation(name: string, rotation: number) : void;
 
         /**
          * Toggles the frame visibility
@@ -230,27 +230,27 @@ declare module 'grafx-studio-actions' {
          * @param include whether the frame is included or not
          * @returns
          */
-        include: (name: string, include: boolean) => void;
+        include(name: string, include: boolean) : void;
 
         /**
          * Returns a list of all Frames
          * @returns
          */
-        all: () => Frame[];
+        all(): Frame[];
 
         /**
          * Returns a specific frame by name
          * @param name the frame name
          * @returns
          */
-        byName: (name: string) => Frame;
+        byName(name: string):Frame;
 
         /**
          * Assigns the specified image variable to the specified image frame
          * @param variableName the image variable name to assign
          * @param frameName the image frame name to assign to
          */
-        assignVariable: (variableName: string, frameName: string) => void;
+        assignVariable(variableName: string, frameName: string) : void;
     }
 
     /**
@@ -262,13 +262,13 @@ declare module 'grafx-studio-actions' {
          * @param name the variable name
          * @returns
          */
-        byName: (name: string) => Variable;
+        byName(name: string) : Variable;
 
         /**
          * Returns a list of all variables
          * @returns
          */
-        all: () => Variable[];
+        all() : Variable[];
 
         /**
          * Sets the value of a variable
@@ -276,12 +276,12 @@ declare module 'grafx-studio-actions' {
          * @param value the value
          * @returns
          */
-        setValue: (name: string, value?: VariableValue) => void;
+        setValue(name: string, value?: VariableValue) : void;
 
         /**
          * Gets the value of a variable
          */
-        getValue: (name: string) => VariableValue;
+        getValue(name: string) : VariableValue;
 
         /**
          * Set the readonly state of a variable
@@ -289,7 +289,7 @@ declare module 'grafx-studio-actions' {
          * @param value whether the variable is readonly
          * @returns
          */
-        setReadonly: (name: string, value: boolean) => void;
+        setReadonly(name: string, value: boolean) : void;
 
         /**
          * Set the required state of a variable
@@ -297,7 +297,7 @@ declare module 'grafx-studio-actions' {
          * @param value whether the variable is required
          * @returns
          */
-        setRequired: (name: string, value: boolean) => void;
+        setRequired(name: string, value: boolean) : void;
 
         /**
          * Set the visible state of a variable
@@ -305,7 +305,7 @@ declare module 'grafx-studio-actions' {
          * @param value whether the variable is visible
          * @returns
          */
-        setVisible: (name: string, value: boolean) => void;
+        setVisible(name: string, value: boolean) : void;
     }
 
     /**
@@ -316,14 +316,14 @@ declare module 'grafx-studio-actions' {
          * Returns the selected layout
          * @returns
          */
-        selected: () => Layout;
+        selected() : Layout;
 
         /**
          * Selects a layout by name
          * @param layoutName the layout name to select
          * @returns
          */
-        select: (layoutName: string) => void;
+        select(layoutName: string) : void;
     }
 
     /**
@@ -334,7 +334,7 @@ declare module 'grafx-studio-actions' {
          * Gets the size of the page
          * @returns the page size
          */
-        getSize: () => Page;
+        getSize() : Page;
 
         /**
          * Sets the size of the page
@@ -342,7 +342,7 @@ declare module 'grafx-studio-actions' {
          * @param height the page height
          * @returns
          */
-        setSize: (width: number, height: number) => void;
+        setSize(width: number, height: number) : void;
     }
 
     /**
@@ -375,7 +375,7 @@ declare module 'grafx-studio-actions' {
          * @param toName the color to copy it to
          * @returns
          */
-        copy: (fromName: string, toName: string) => void;
+        copy(fromName: string, toName: string) : void;
     }
 
     /**
@@ -388,7 +388,7 @@ declare module 'grafx-studio-actions' {
          * @param toName the paragraph style to copy it to
          * @returns
          */
-        copy: (fromName: string, toName: string) => void;
+        copy(fromName: string, toName: string) : void;
     }
 
     /**
@@ -401,6 +401,6 @@ declare module 'grafx-studio-actions' {
          * @param toName the character style to copy it to
          * @returns
          */
-        copy: (fromName: string, toName: string) => void;
+        copy(fromName: string, toName: string) : void;
     }
 }

--- a/types/Actions.d.ts
+++ b/types/Actions.d.ts
@@ -173,7 +173,7 @@ declare module 'grafx-studio-actions' {
          * @param y the frame y position
          * @returns
          */
-        move(name: string, x: number, y: number) : void;
+        move(name: string, x: number, y: number): void;
 
         /**
          * Resizes a frame to a specified size
@@ -182,7 +182,7 @@ declare module 'grafx-studio-actions' {
          * @param height the frame height
          * @returns
          */
-        resize(name: string, width: number, height: number) : void;
+        resize(name: string, width: number, height: number): void;
 
         /**
          * Moves a frame to a specified X position
@@ -190,7 +190,7 @@ declare module 'grafx-studio-actions' {
          * @param x the frame x position
          * @returns
          */
-        setX(name: string, x: number) : void;
+        setX(name: string, x: number): void;
 
         /**
          * Moves a frame to a specified Y position
@@ -198,7 +198,7 @@ declare module 'grafx-studio-actions' {
          * @param y the frame y position
          * @returns
          */
-        setY(name: string, y: number) : void;
+        setY(name: string, y: number): void;
 
         /**
          * Resizes a frame to a specified width
@@ -206,7 +206,7 @@ declare module 'grafx-studio-actions' {
          * @param width the frame width
          * @returns
          */
-        setWidth(name: string, width: number) : void;
+        setWidth(name: string, width: number): void;
 
         /**
          * Resizes a frame to a specified height
@@ -214,7 +214,7 @@ declare module 'grafx-studio-actions' {
          * @param height the frame height
          * @returns
          */
-        setHeight(name: string, height: number) : void;
+        setHeight(name: string, height: number): void;
 
         /**
          * Rotates a frame to a specified degree
@@ -222,7 +222,7 @@ declare module 'grafx-studio-actions' {
          * @param rotation the frame rotation in degrees
          * @returns
          */
-        setRotation(name: string, rotation: number) : void;
+        setRotation(name: string, rotation: number): void;
 
         /**
          * Toggles the frame visibility
@@ -230,7 +230,7 @@ declare module 'grafx-studio-actions' {
          * @param include whether the frame is included or not
          * @returns
          */
-        include(name: string, include: boolean) : void;
+        include(name: string, include: boolean): void;
 
         /**
          * Returns a list of all Frames
@@ -243,14 +243,14 @@ declare module 'grafx-studio-actions' {
          * @param name the frame name
          * @returns
          */
-        byName(name: string):Frame;
+        byName(name: string): Frame;
 
         /**
          * Assigns the specified image variable to the specified image frame
          * @param variableName the image variable name to assign
          * @param frameName the image frame name to assign to
          */
-        assignVariable(variableName: string, frameName: string) : void;
+        assignVariable(variableName: string, frameName: string): void;
     }
 
     /**
@@ -262,13 +262,13 @@ declare module 'grafx-studio-actions' {
          * @param name the variable name
          * @returns
          */
-        byName(name: string) : Variable;
+        byName(name: string): Variable;
 
         /**
          * Returns a list of all variables
          * @returns
          */
-        all() : Variable[];
+        all(): Variable[];
 
         /**
          * Sets the value of a variable
@@ -276,12 +276,12 @@ declare module 'grafx-studio-actions' {
          * @param value the value
          * @returns
          */
-        setValue(name: string, value?: VariableValue) : void;
+        setValue(name: string, value?: VariableValue): void;
 
         /**
          * Gets the value of a variable
          */
-        getValue(name: string) : VariableValue;
+        getValue(name: string): VariableValue;
 
         /**
          * Set the readonly state of a variable
@@ -289,7 +289,7 @@ declare module 'grafx-studio-actions' {
          * @param value whether the variable is readonly
          * @returns
          */
-        setReadonly(name: string, value: boolean) : void;
+        setReadonly(name: string, value: boolean): void;
 
         /**
          * Set the required state of a variable
@@ -297,7 +297,7 @@ declare module 'grafx-studio-actions' {
          * @param value whether the variable is required
          * @returns
          */
-        setRequired(name: string, value: boolean) : void;
+        setRequired(name: string, value: boolean): void;
 
         /**
          * Set the visible state of a variable
@@ -305,7 +305,7 @@ declare module 'grafx-studio-actions' {
          * @param value whether the variable is visible
          * @returns
          */
-        setVisible(name: string, value: boolean) : void;
+        setVisible(name: string, value: boolean): void;
     }
 
     /**
@@ -316,14 +316,14 @@ declare module 'grafx-studio-actions' {
          * Returns the selected layout
          * @returns
          */
-        selected() : Layout;
+        selected(): Layout;
 
         /**
          * Selects a layout by name
          * @param layoutName the layout name to select
          * @returns
          */
-        select(layoutName: string) : void;
+        select(layoutName: string): void;
     }
 
     /**
@@ -334,7 +334,7 @@ declare module 'grafx-studio-actions' {
          * Gets the size of the page
          * @returns the page size
          */
-        getSize() : Page;
+        getSize(): Page;
 
         /**
          * Sets the size of the page
@@ -342,7 +342,7 @@ declare module 'grafx-studio-actions' {
          * @param height the page height
          * @returns
          */
-        setSize(width: number, height: number) : void;
+        setSize(width: number, height: number): void;
     }
 
     /**
@@ -375,7 +375,7 @@ declare module 'grafx-studio-actions' {
          * @param toName the color to copy it to
          * @returns
          */
-        copy(fromName: string, toName: string) : void;
+        copy(fromName: string, toName: string): void;
     }
 
     /**
@@ -388,7 +388,7 @@ declare module 'grafx-studio-actions' {
          * @param toName the paragraph style to copy it to
          * @returns
          */
-        copy(fromName: string, toName: string) : void;
+        copy(fromName: string, toName: string): void;
     }
 
     /**
@@ -401,6 +401,6 @@ declare module 'grafx-studio-actions' {
          * @param toName the character style to copy it to
          * @returns
          */
-        copy(fromName: string, toName: string) : void;
+        copy(fromName: string, toName: string): void;
     }
 }


### PR DESCRIPTION
This PR makes Action methods show up correctly as methods instead of properties. 
