### PR TITLE
[Feature] Extend action models with layout list and size

### DIFF
--- a/types/Actions.d.ts
+++ b/types/Actions.d.ts
@@ -106,6 +106,8 @@ declare module 'grafx-studio-actions' {
      */
     interface Layout {
         readonly name: string;
+        readonly width: number;
+        readonly height: number;
     }
 
     /** Respresents a Variable inside Actions */
@@ -324,6 +326,11 @@ declare module 'grafx-studio-actions' {
          * @returns
          */
         select(layoutName: string): void;
+
+        /**
+         * Returns all layouts in the document.
+         */
+        all(): Layout[];
     }
 
     /**


### PR DESCRIPTION
This PR add `Studio.layouts.all()` and adds `width`, `height` properties to the `Layout` model. 
