### PR TITLE
[EDT-11121] updated download && preview methods + new DTP's

### DIFF
--- a/src/tests/controllers/FontConnectorController.test.ts
+++ b/src/tests/controllers/FontConnectorController.test.ts
@@ -1,8 +1,8 @@
 import { FontConnectorController } from '../../controllers/FontConnectorController';
 import { SortBy, SortOrder } from '../../types/ConnectorTypes';
-import { FontDownloadType } from '../../types/FontConnectorTypes';
+import { FontPreviewFormat } from '../../types/FontConnectorTypes';
 import { EditorAPI } from '../../types/CommonTypes';
-import { getEditorResponseData, castToEditorResponse } from '../../utils/EditorResponseData';
+import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorResponseData';
 
 let mockedFontConnectorController: FontConnectorController;
 
@@ -10,6 +10,7 @@ const mockedEditorApi: EditorAPI = {
     fontConnectorCopy: async () => getEditorResponseData(castToEditorResponse(null)),
     fontConnectorQuery: async () => getEditorResponseData(castToEditorResponse(null)),
     fontConnectorDownload: async () => getEditorResponseData(castToEditorResponse(null)),
+    fontConnectorPreview: async () => getEditorResponseData(castToEditorResponse(null)),
     fontConnectorUpload: async () => getEditorResponseData(castToEditorResponse(null)),
     fontConnectorRemove: async () => getEditorResponseData(castToEditorResponse(null)),
     fontConnectorDetail: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -23,6 +24,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'fontConnectorQuery');
     jest.spyOn(mockedEditorApi, 'fontConnectorCopy');
     jest.spyOn(mockedEditorApi, 'fontConnectorDownload');
+    jest.spyOn(mockedEditorApi, 'fontConnectorPreview');
     jest.spyOn(mockedEditorApi, 'fontConnectorRemove');
     jest.spyOn(mockedEditorApi, 'fontConnectorUpload');
     jest.spyOn(mockedEditorApi, 'fontConnectorDetail');
@@ -80,12 +82,22 @@ describe('FontConnectorController', () => {
     });
 
     it('Should call the download method', async () => {
-        await mockedFontConnectorController.download(connectorId, fontId, FontDownloadType.Preview, context);
+        await mockedFontConnectorController.download(connectorId, fontId, context);
         expect(mockedEditorApi.fontConnectorDownload).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.fontConnectorDownload).toHaveBeenCalledWith(
             connectorId,
             fontId,
-            FontDownloadType.Preview,
+            JSON.stringify(context),
+        );
+    });
+
+    it('Should call the preview method', async () => {
+        await mockedFontConnectorController.preview(connectorId, fontId, FontPreviewFormat.Square, context);
+        expect(mockedEditorApi.fontConnectorPreview).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.fontConnectorPreview).toHaveBeenCalledWith(
+            connectorId,
+            fontId,
+            FontPreviewFormat.Square,
             JSON.stringify(context),
         );
     });

--- a/src/types/FontConnectorTypes.ts
+++ b/src/types/FontConnectorTypes.ts
@@ -1,24 +1,26 @@
 import { Id } from './CommonTypes';
-import { MediaType } from './ConnectorTypes';
 
-export enum FontDownloadType {
-    Preview = 'lowresWeb',
-    Download = 'outputPdf',
+export enum FontPreviewFormat {
+    Square = 'square',
+    Line = 'line',
 }
 
-export type Font = {
+export type FontFamily = {
     id: Id;
     name: string;
-    family: string | null;
-    style: string | null;
-    relativePath: string;
-    type: MediaType;
-    extension: string | null;
-    metaData: Map<string, string>;
+    fontStylesCount: number;
+    extensions: string[];
+};
+
+export type FontStyle = {
+    id: Id;
+    name: string;
+    familyId: string;
+    familyName: string;
 };
 
 export type FontPage = {
     pageSize: number;
     nextPageToken?: string;
-    data: Font[];
+    data: FontFamily[];
 };


### PR DESCRIPTION
This PR introduces Font Families support by:
- Adjusting `download` method (by removing `previewType`)
- Adding a `preview` method with `previewFormat` param
- Adding new models: `FontFamily` + `FontStyle`

## Related tickets

-   [EDT-1121](https://chilipublishintranet.atlassian.net/browse/EDT-1121)
