### PR TITLE
[Fix] rename engine to info to be consistent

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -112,7 +112,7 @@ export class SDK {
         this.experiment = new ExperimentController(this.editorAPI);
         this.canvas = new CanvasController(this.editorAPI);
         this.colorConversion = new ColorConversionController(this.editorAPI);
-        this.engine = new InfoController();
+        this.info = new InfoController();
     }
 
     /**
@@ -181,7 +181,7 @@ export class SDK {
         this.experiment = new ExperimentController(this.editorAPI);
         this.canvas = new CanvasController(this.editorAPI);
         this.shape = new ShapeController(this.editorAPI);
-        this.engine = new InfoController();
+        this.info = new InfoController();
 
         // as soon as the editor loads, provide it with the SDK version
         // used to make it start. This enables engine compatibility checks

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -71,7 +71,7 @@ export class SDK {
     experiment: ExperimentController;
     canvas: CanvasController;
     colorConversion: ColorConversionController;
-    engine: InfoController;
+    info: InfoController;
 
     private subscriber: SubscriberController;
 


### PR DESCRIPTION
This PR fixes the naming of engine to info for consistency
