### PR TITLE
[Feature] [EDT-1148] Connector & State getter refactor

### DIFF
--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -37,6 +37,16 @@ export class ConnectorController {
     }
 
     /**
+     * Gets a connector by its id
+     * @param id the id of the connector
+     * @returns connector
+     */
+    getById = async (id: Id) => {
+        const res = await this.#editorAPI;
+        return res.getConnectorById(id).then((result) => getEditorResponseData<ConnectorInstance>(result));
+    };
+
+    /**
      * Gets all available connectors of a 'ConnectorType'
      * @param type type of connector you want to get
      * @returns list of all available connectors of a 'ConnectorType'

--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -85,7 +85,7 @@ export class ConnectorController {
      * @param configurationCallback callback to setup the connector
      * @returns
      */
-    configure = async (id: string, configurationCallback: (configurator: ConnectorConfigurator) => Promise<void>) => {
+    configure = async (id: Id, configurationCallback: (configurator: ConnectorConfigurator) => Promise<void>) => {
         const res = await this.#editorAPI;
         // wait for connector to be ready
         await this.waitToBeReady(id);
@@ -101,7 +101,7 @@ export class ConnectorController {
      * @param id the id of your registered connector you want to make sure it is loaded
      * @returns connector state
      */
-    getState = async (id: string) => {
+    getState = async (id: Id) => {
         const res = await this.#editorAPI;
         return res.getConnectorState(id).then((result) => getEditorResponseData<ConnectorState>(result));
     };
@@ -114,7 +114,7 @@ export class ConnectorController {
      * @param id the id of your registered connector you want to make sure it is loaded
      * @returns
      */
-    waitToBeReady = async (id: string, timeoutMilliseconds = 2000): Promise<EditorResponse<null>> => {
+    waitToBeReady = async (id: Id, timeoutMilliseconds = 2000): Promise<EditorResponse<null>> => {
         // minimum timeout is 500ms
         let timeout = Math.max(timeoutMilliseconds, 500);
 
@@ -178,13 +178,13 @@ class ConnectorConfigurator {
     /**
      * @ignore
      */
-    #connectorId: string;
+    #connectorId: Id;
     #res: EditorAPI;
 
     /**
      * @ignore
      */
-    constructor(id: string, res: EditorAPI) {
+    constructor(id: Id, res: EditorAPI) {
         this.#connectorId = id;
         this.#res = res;
     }

--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -91,7 +91,7 @@ export class ConnectorController {
      * @param id the id of your registered connector you want to make sure it is loaded
      * @returns connector state
      */
-    getById = async (id: string) => {
+    getStateById = async (id: string) => {
         const res = await this.#editorAPI;
         return res.getConnectorState(id).then((result) => getEditorResponseData<ConnectorState>(result));
     };
@@ -118,7 +118,7 @@ export class ConnectorController {
             // using while loop will prevent stack overflow issues when using recursion
             // wait for maximum 2 seconds to fail
             while (retries * waitTime < timeout) {
-                const result = await this.getById(id);
+                const result = await this.getStateById(id);
 
                 if (
                     result.success &&

--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -101,7 +101,7 @@ export class ConnectorController {
      * @param id the id of your registered connector you want to make sure it is loaded
      * @returns connector state
      */
-    getStateById = async (id: string) => {
+    getState = async (id: string) => {
         const res = await this.#editorAPI;
         return res.getConnectorState(id).then((result) => getEditorResponseData<ConnectorState>(result));
     };
@@ -128,7 +128,7 @@ export class ConnectorController {
             // using while loop will prevent stack overflow issues when using recursion
             // wait for maximum 2 seconds to fail
             while (retries * waitTime < timeout) {
-                const result = await this.getStateById(id);
+                const result = await this.getState(id);
 
                 if (
                     result.success &&

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -72,8 +72,8 @@ describe('ConnectorController', () => {
         expect(mockEditorApi.getConnectors).toHaveBeenCalledWith(ConnectorType.media);
     });
 
-    it('Should call the getStateById method', async () => {
-        await mockedConnectorController.getStateById(connectorId);
+    it('Should call the getState method', async () => {
+        await mockedConnectorController.getState(connectorId);
         expect(mockEditorApi.getConnectorState).toHaveBeenCalledTimes(1);
     });
 

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -61,11 +61,6 @@ describe('ConnectorController', () => {
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
     });
 
-    it('Should call the getAllByType method', async () => {
-        await mockedConnectorController.getAllByType(ConnectorType.media);
-        expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
-    });
-
     it('Should be possible to retrieve all connectors of a certain type', async () => {
         await mockedConnectorController.getAllByType(ConnectorType.media);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -12,6 +12,7 @@ import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorR
 let mockedConnectorController: ConnectorController;
 
 const mockEditorApi: EditorAPI = {
+    getConnectorById: async () => getEditorResponseData(castToEditorResponse(null)),
     getConnectors: async () => getEditorResponseData(castToEditorResponse(null)),
     registerConnector: async () => getEditorResponseData(castToEditorResponse(null)),
     unregisterConnector: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -25,6 +26,7 @@ const mockEditorApi: EditorAPI = {
 
 beforeEach(() => {
     mockedConnectorController = new ConnectorController(mockEditorApi);
+    jest.spyOn(mockEditorApi, 'getConnectorById');
     jest.spyOn(mockEditorApi, 'getConnectors');
     jest.spyOn(mockEditorApi, 'registerConnector');
     jest.spyOn(mockEditorApi, 'unregisterConnector');
@@ -49,29 +51,44 @@ describe('ConnectorController', () => {
     const headerName = 'headerName';
     const headerValue = 'headerValue';
 
+    it('Should call the getById method', async () => {
+        await mockedConnectorController.getById(connectorId);
+        expect(mockEditorApi.getConnectorById).toHaveBeenCalledTimes(1);
+    });
+
     it('Should call the getAllByType method', async () => {
         await mockedConnectorController.getAllByType(ConnectorType.media);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
     });
+
+    it('Should call the getAllByType method', async () => {
+        await mockedConnectorController.getAllByType(ConnectorType.media);
+        expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
+    });
+
     it('Should be possible to retrieve all connectors of a certain type', async () => {
         await mockedConnectorController.getAllByType(ConnectorType.media);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledWith(ConnectorType.media);
     });
+
     it('Should call the getStateById method', async () => {
         await mockedConnectorController.getStateById(connectorId);
         expect(mockEditorApi.getConnectorState).toHaveBeenCalledTimes(1);
     });
+
     it('Should be possible to register a connector', async () => {
         await mockedConnectorController.register(registration);
         expect(mockEditorApi.registerConnector).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.registerConnector).toHaveBeenCalledWith(JSON.stringify(registration));
     });
+
     it('Should be possible to unregister a connector', async () => {
         await mockedConnectorController.unregister(connectorId);
         expect(mockEditorApi.unregisterConnector).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.unregisterConnector).toHaveBeenCalledWith(connectorId);
     });
+
     it('Should be possible to configure a connector', async () => {
         await mockedConnectorController.configure(connectorId, async (configurator) => {
             configurator.setHttpHeader(headerName, headerValue);

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -58,8 +58,8 @@ describe('ConnectorController', () => {
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledWith(ConnectorType.media);
     });
-    it('Should call the getById method', async () => {
-        await mockedConnectorController.getById(connectorId);
+    it('Should call the getStateById method', async () => {
+        await mockedConnectorController.getStateById(connectorId);
         expect(mockEditorApi.getConnectorState).toHaveBeenCalledTimes(1);
     });
     it('Should be possible to register a connector', async () => {


### PR DESCRIPTION
Engine ticket: https://chilipublishintranet.atlassian.net/browse/EDT-1148

Can be tested against https://studio.chiligrafx-dev.com/?workspace=latest&engine=484&engineCommitSha=e6079e3ebfc15f0bfc18e33eeebee6058d778923

- `SDK.connector.getById` is now returning a `ConnectorInstance` (to align with `getAllByType`). It was originally returning a `ConnectorState` object and was confusing.
- `SDK.connector.getState` is the new name for the old `getById`, it returns a `ConnectorState`.

