### PR TITLE
[Fix] Add setTypeError method for actions

### DIFF
--- a/packages/sdk/src/controllers/ActionController.ts
+++ b/packages/sdk/src/controllers/ActionController.ts
@@ -112,4 +112,19 @@ export class ActionController {
         const res = await this.#editorAPI;
         return res.moveActions(order, ids).then((result) => getEditorResponseData<null>(result));
     };
+
+    /**
+     * This method stores the state of action type errors to the document
+     * 
+     * An async error will be sent back to the SDK when an action is loaded again:
+     * - on document load
+     * - after an `updateScript` call
+     * @param id the id of a specific action
+     * @param hasTypeErrors whether there is an action type error
+     * @returns
+     */
+    setTypeError = async (id: string, hasTypeErrors: boolean) => {
+        const res = await this.#editorAPI;
+        return res.setActionTypeError(id, hasTypeErrors).then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/packages/sdk/src/controllers/ActionController.ts
+++ b/packages/sdk/src/controllers/ActionController.ts
@@ -116,9 +116,8 @@ export class ActionController {
     /**
      * This method stores the state of action type errors to the document
      * 
-     * An async error will be sent back to the SDK when an action is loaded again:
-     * - on document load
-     * - after an `updateScript` call
+     * Those errors states can be read back from the usual getters or the
+     * `onActionsChanged` stream
      * @param id the id of a specific action
      * @param hasTypeErrors whether there is an action type error
      * @returns

--- a/packages/sdk/src/tests/controllers/ActionController.test.ts
+++ b/packages/sdk/src/tests/controllers/ActionController.test.ts
@@ -15,6 +15,7 @@ const mockEditorApi: EditorAPI = {
     updateActionScript: async () => getEditorResponseData(castToEditorResponse(null)),
     updateActionTriggers: async () => getEditorResponseData(castToEditorResponse(null)),
     moveActions: async () => getEditorResponseData(castToEditorResponse(null)),
+    setActionTypeError: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -28,6 +29,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'updateActionScript');
     jest.spyOn(mockEditorApi, 'updateActionTriggers');
     jest.spyOn(mockEditorApi, 'moveActions');
+    jest.spyOn(mockEditorApi, 'setActionTypeError');
 });
 
 afterAll(() => {
@@ -99,5 +101,11 @@ describe('Should call all of the ActionController functions of child successfull
         await mockedActionController.move(order, ids);
         expect(mockEditorApi.moveActions).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.moveActions).toHaveBeenCalledWith(order, ids);
+    });
+
+    it('should call removeAction function of EditorAPI', async () => {
+        await mockedActionController.setTypeError('0', true);
+        expect(mockEditorApi.setActionTypeError).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.setActionTypeError).toHaveBeenCalledWith('0', true);
     });
 });


### PR DESCRIPTION
## Related tickets
https://chilipublishintranet.atlassian.net/browse/EDT-1156
https://chilipublishintranet.atlassian.net/browse/WRS-1342

---

## PR

A new `ActionController.setTypeError(id: string, hasTypeErrors: boolean)` has been added.

This is a way for the workspace to keep the state of the type errors (driven by WRS/monaco) after a new document load.

The error can be read from the usual action/document getters & most probably via the `actionsChanged` stream.
