### PR TITLE
[Feature] Error handling by throw

### DIFF
--- a/packages/sdk/src/tests/controllers/ConnectorController.test.ts
+++ b/packages/sdk/src/tests/controllers/ConnectorController.test.ts
@@ -18,7 +18,7 @@ const mockEditorApi: EditorAPI = {
     unregisterConnector: async () => getEditorResponseData(castToEditorResponse(null)),
     connectorAuthenticationSetChiliToken: async () => getEditorResponseData(castToEditorResponse(null)),
     updateConnectorConfiguration: async () => getEditorResponseData(castToEditorResponse(null)),
-    getConnectorState: async () => getEditorResponseData(castToEditorResponse(null)),
+    getConnectorState: async () => getEditorResponseData(castToEditorResponse({ id: '', type: 'ready' })),
     connectorAuthenticationSetHttpHeader: async () => getEditorResponseData(castToEditorResponse(null)),
     setConnectorOptions: async () => getEditorResponseData(castToEditorResponse(null)),
     setConnectorMappings: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -65,26 +65,22 @@ describe('ConnectorController', () => {
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
     });
 
-
     it('Should be possible to retrieve all connectors of a certain type', async () => {
         await mockedConnectorController.getAllByType(ConnectorType.media);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getConnectors).toHaveBeenCalledWith(ConnectorType.media);
     });
 
-
     it('Should call the getState method', async () => {
         await mockedConnectorController.getState(connectorId);
         expect(mockEditorApi.getConnectorState).toHaveBeenCalledTimes(1);
     });
-
 
     it('Should be possible to register a connector', async () => {
         await mockedConnectorController.register(registration);
         expect(mockEditorApi.registerConnector).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.registerConnector).toHaveBeenCalledWith(JSON.stringify(registration));
     });
-
 
     it('Should be possible to unregister a connector', async () => {
         await mockedConnectorController.unregister(connectorId);
@@ -103,7 +99,6 @@ describe('ConnectorController', () => {
         expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledWith(connectorId);
     });
-
 
     it('Should be possible to configure a connector', async () => {
         await mockedConnectorController.configure(connectorId, async (configurator) => {

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -53,11 +53,13 @@ export type ConfigType = {
     onAsyncError?: (asyncError: AsyncError) => void;
 };
 
+export type EditorResponseError = string;
+
 export interface EditorResponse<T> {
     success: boolean;
     status: number;
     data?: string | null;
-    error?: string | { code: number; error: Record<string, unknown> } | null;
+    error?: EditorResponseError | null;
     parsedData: T | null;
 }
 

--- a/packages/sdk/src/utils/EditorResponseData.ts
+++ b/packages/sdk/src/utils/EditorResponseData.ts
@@ -3,7 +3,12 @@ import type { EditorResponse } from '../types/CommonTypes';
 export function getEditorResponseData<T>(response: EditorResponse<unknown>, parse = true): EditorResponse<T> {
     try {
         if (!response.success) {
-            throw new Error(response.error ?? 'Yikes, something went wrong');
+            throw new Error(response.error ?? 'Yikes, something went wrong', {
+                cause: {
+                    name: String(response.status),
+                    message: response.error ?? 'Yikes, something went wrong',
+                },
+            });
         }
         const dataShouldBeParsed = response.data && parse;
         return {

--- a/packages/sdk/src/utils/EditorResponseData.ts
+++ b/packages/sdk/src/utils/EditorResponseData.ts
@@ -1,17 +1,24 @@
-import { EditorResponse } from '../types/CommonTypes';
+import type { EditorResponse } from '../types/CommonTypes';
 
 export function getEditorResponseData<T>(response: EditorResponse<unknown>, parse = true): EditorResponse<T> {
-    return {
-        ...response,
-        parsedData:
-            response.success && response.data
-                ? parse
-                    ? (JSON.parse(response.data as string) as T)
-                    : (response.data as unknown as T)
-                : null,
-    };
+    try {
+        if (!response.success) {
+            throw new Error(response.error ?? 'Yikes, something went wrong');
+        }
+        const dataShouldBeParsed = response.data && parse;
+        return {
+            ...response,
+            parsedData: dataShouldBeParsed
+                ? (JSON.parse(response.data as string) as T)
+                : (response.data as unknown as T),
+        };
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
 }
 
+// For testing purposes only
 export function castToEditorResponse(toCast: unknown): EditorResponse<unknown> {
     return {
         status: 200,


### PR DESCRIPTION
This PR is a POC on throwing errors.
The SDK will now throw errors when something goes wrong instead of success status false.
