### PR TITLE
[Feature] Add width & height to media detail model

### DIFF
--- a/packages/sdk/src/controllers/MediaConnectorController.ts
+++ b/packages/sdk/src/controllers/MediaConnectorController.ts
@@ -8,7 +8,7 @@ import {
     QueryPage,
 } from '../types/ConnectorTypes';
 import { CallSender } from 'penpal';
-import { Media, MediaDownloadType } from '../types/MediaConnectorTypes';
+import { Media, MediaDetail, MediaDownloadType } from '../types/MediaConnectorTypes';
 
 /**
  * The MediaConnectorController is responsible for all communication regarding media connectors.
@@ -65,7 +65,7 @@ export class MediaConnectorController {
         const res = await this.#editorAPI;
         return res
             .mediaConnectorDetail(id, mediaId, JSON.stringify(context))
-            .then((result) => getEditorResponseData<Media>(result));
+            .then((result) => getEditorResponseData<MediaDetail>(result));
     };
 
     /**

--- a/packages/sdk/src/types/ConnectorTypes.ts
+++ b/packages/sdk/src/types/ConnectorTypes.ts
@@ -125,6 +125,7 @@ export type ConnectorEvent = {
 };
 
 export type QueryPage<T> = {
+    pageSize: number;
     nextPageToken?: string;
     data: T[];
 };

--- a/packages/sdk/src/types/FontConnectorTypes.ts
+++ b/packages/sdk/src/types/FontConnectorTypes.ts
@@ -18,9 +18,3 @@ export type FontStyle = {
     familyId: string;
     familyName: string;
 };
-
-export type FontPage = {
-    pageSize: number;
-    nextPageToken?: string;
-    data: FontFamily[];
-};

--- a/packages/sdk/src/types/MediaConnectorTypes.ts
+++ b/packages/sdk/src/types/MediaConnectorTypes.ts
@@ -22,8 +22,3 @@ export interface MediaDetail extends Media {
     height?: number;
 };
 
-export type MediaPage = {
-    pageSize: number;
-    nextPageToken?: string;
-    data: Media[];
-};

--- a/packages/sdk/src/types/MediaConnectorTypes.ts
+++ b/packages/sdk/src/types/MediaConnectorTypes.ts
@@ -17,6 +17,11 @@ export type Media = {
     };
 };
 
+export interface MediaDetail extends Media {
+    width?: number;
+    height?: number;
+};
+
 export type MediaPage = {
     pageSize: number;
     nextPageToken?: string;

--- a/types/Connector.Shared.d.ts
+++ b/types/Connector.Shared.d.ts
@@ -16,11 +16,14 @@ export interface ConnectorRuntimeContext {
     sdkVersion: string;
 }
 
-export enum DownloadType {
-    lowres_web = 'lowresweb',
-    highres_web = 'highresweb',
-    outputVideo = 'outputVideo',
-    outputPdf = 'outputPdf'
+
+export type ConnectorCapabilities = {
+    filtering: boolean;
+    upload: boolean;
+    query: boolean;
+    detail: boolean;
+    remove: boolean;
+    copy: boolean;
 }
 
 export type QueryOptions = {

--- a/types/FontConnector.d.ts
+++ b/types/FontConnector.d.ts
@@ -1,36 +1,39 @@
-import { QueryOptions, Dictionary, ArrayBufferPointer, DownloadType, ConnectorConfigOptions } from "./Connector.Shared";
+import { QueryOptions, Dictionary, ArrayBufferPointer, ConnectorConfigOptions, ConnectorCapabilities } from "./Connector.Shared";
 
 declare module "grafx-studio-fontconnector" {
     interface GrafxFontConnector {
-        detail(id, context: Dictionary): Font;
-        query(options: QueryOptions, context: Dictionary): Promise<FontPage>;
-        download(id: string, previewType: DownloadType, context: Dictionary): Promise<ArrayBufferPointer>
+        detail(familyId, context: Dictionary): FontStyle;
+        query(options: QueryOptions, context: Dictionary): Promise<FontFamilyPage>;
+        download(styleId: string, context: Dictionary): Promise<ArrayBufferPointer>
+        preview(familyId: string, previewFormat: FontPreviewFormat, context: Dictionary): Promise<ArrayBufferPointer>
         getConfigurationOptions(): ConnectorConfigOptions | null;
-        getCapabilities(): FontConnectorCapabilities;
+        getCapabilities(): ConnectorCapabilities;
     }
 
-    type FontConnectorCapabilities = {
-        filtering: boolean;
-        query: boolean;
-        detail: boolean;
+    export enum FontPreviewFormat {
+        Square = 'square',
+        Line = 'line',
     }
 
-    interface FontPage {
+    export interface FontFamilyPage {
         pageSize: number;
-        data: Font[];
+        data: FontFamily[];
         links: {
             nextPage: string;
         };
     }
-    
-    interface Font {
-        id: string,
-        name: string,
-        relativePath: string,
-        extension: string,
-        type: number,
-        family: string,
-        style: string,
-        metaData: Dictionary;
+
+    interface FontFamily {
+        id: string;
+        name: string;
+        fontStylesCount: number;
+        extensions: string[];
+    }
+
+    interface FontStyle {
+        id: string;
+        name: string;
+        familyId: string;
+        familyName: string;
     }
 }

--- a/types/FontConnector.d.ts
+++ b/types/FontConnector.d.ts
@@ -10,12 +10,12 @@ declare module "grafx-studio-fontconnector" {
         getCapabilities(): ConnectorCapabilities;
     }
 
-    export enum FontPreviewFormat {
+    enum FontPreviewFormat {
         Square = 'square',
         Line = 'line',
     }
 
-    export interface FontFamilyPage {
+    interface FontFamilyPage {
         pageSize: number;
         data: FontFamily[];
         links: {

--- a/types/MediaConnector.d.ts
+++ b/types/MediaConnector.d.ts
@@ -12,8 +12,8 @@ export interface MediaConnector {
 }
 
 export enum DownloadType {
-    lowres_web = 'lowresweb',
-    highres_web = 'highresweb',
+    lowresWeb = 'lowresWeb',
+    highresWeb = 'highresWeb',
     outputVideo = 'outputVideo',
     outputPdf = 'outputPdf'
 }

--- a/types/MediaConnector.d.ts
+++ b/types/MediaConnector.d.ts
@@ -1,23 +1,21 @@
-import { QueryOptions, Dictionary, ArrayBufferPointer, DownloadType, ConnectorConfigOptions } from "./Connector.Shared";
+import { QueryOptions, Dictionary, ArrayBufferPointer, ConnectorConfigOptions, ConnectorCapabilities } from "./Connector.Shared";
 
 export interface MediaConnector {
-    query(options: QueryOptions, context: Dictionary): Promise<MediaPage>;
     detail(id: string, context: Dictionary): Promise<MediaDetail>;
+    query(options: QueryOptions, context: Dictionary): Promise<MediaPage>;
     download(id: string, previewType: DownloadType, context: Dictionary): Promise<ArrayBufferPointer>
     upload(name: string, blob: ArrayBufferPointer, context: Dictionary): Promise<Media>
     remove(id: string, context: Dictionary): Promise<boolean>
     copy(id: string, newName: string, context: Dictionary): Promise<Media>
     getConfigurationOptions(): ConnectorConfigOptions | null;
-    getCapabilities(): MediaConnectorCapabilities;
+    getCapabilities(): ConnectorCapabilities;
 }
 
-export type MediaConnectorCapabilities = {
-    filtering: boolean;
-    upload: boolean;
-    query: boolean;
-    detail: boolean;
-    remove: boolean;
-    copy: boolean;
+export enum DownloadType {
+    lowres_web = 'lowresweb',
+    highres_web = 'highresweb',
+    outputVideo = 'outputVideo',
+    outputPdf = 'outputPdf'
 }
 
 export interface MediaPage {
@@ -34,10 +32,10 @@ export interface Media {
     relativePath: string;
     type: number;
     metaData: Dictionary;
+    extension?: string;
 }
 
 export interface MediaDetail extends Media {
     width?: number;
     height?: number;
-    extension?: string;
 }


### PR DESCRIPTION
This PR adds `width` & `height` to the model returned by the connector `detail` method. `MediaDetail` model is now diverging from `Media` (query method).

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1054
