### PR TITLE
[Fix] Safer undo record method

### DIFF
--- a/packages/sdk/src/controllers/UndoManagerController.ts
+++ b/packages/sdk/src/controllers/UndoManagerController.ts
@@ -49,7 +49,7 @@ export class UndoManagerController {
      */
     record = async (operationName: string, undoOperationCallback: (sdk: SDK) => void) => {
         try {
-            await this.#advanced.begin(operationName);
+            await this.#advanced.beginIfNoneActive(operationName);
 
             await undoOperationCallback(this.#sdk);
         } catch (error) {

--- a/packages/sdk/src/tests/controllers/UndoManagerController.test.ts
+++ b/packages/sdk/src/tests/controllers/UndoManagerController.test.ts
@@ -51,7 +51,7 @@ describe('UndoManagerController', () => {
             dummy = true;
         });
 
-        expect(mockEditorApi.begin).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.beginIfNoneActive).toHaveBeenCalledTimes(1);
         expect(dummy).toBe(true);
         expect(mockEditorApi.end).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
As per the SDK doc or the [proposal](https://github.com/chili-publish/studio-engine/blob/main/proposals/08-04-2022-Undo-Redo-API.md), `begin` will throw if there is a current undo operation.

1. `record` has been introduced 4 weeks ago
2. Halim's PR is the firs use of record
3. Before the PR a throw could have happened if you wrapped a record into another record

Using `beginIfNoneActive` instead of `begin` makes sure we're not throwing (and not recording) because parent is recording already.
