### PR TITLE
[Fix] export `SelectedTextStyle` type from index.ts

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -73,6 +73,7 @@ export type {
 
 export type {
     TextProperties,
+    SelectedTextStyle,
     TextStyle,
     AppearanceProperties,
     TextStyleUpdateType,


### PR DESCRIPTION
This PR exports `SelectedTextStyle` type from index.ts

## Related tickets
## Screenshots
