### PR TITLE
[Feature] Add Action delta update method

### DIFF
--- a/packages/sdk/src/controllers/ActionController.ts
+++ b/packages/sdk/src/controllers/ActionController.ts
@@ -1,4 +1,4 @@
-import { ActionTrigger, DocumentAction } from '../types/ActionTypes';
+import { ActionDeltaUpdate, ActionTrigger, DocumentAction } from '../types/ActionTypes';
 import { EditorAPI, Id } from '../types/CommonTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 
@@ -68,38 +68,50 @@ export class ActionController {
     };
 
     /**
+     * This method updates an existing Action
+     * @param id the id of a specific Action
+     * @param update the delta update to apply to the Action
+     * @returns
+     */
+    update = async (id: Id, update: ActionDeltaUpdate) => {
+        const res = await this.#editorAPI;
+        return res.updateAction(id, JSON.stringify(update)).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * @deprecated use the update method instead
+     *
      * This method renames an action by the id and provided name
      * @param id the id of a specific action
      * @param name the new unique name for the action
      * @returns
      */
     rename = async (id: Id, name: string) => {
-        const res = await this.#editorAPI;
-        return res.renameAction(id, name).then((result) => getEditorResponseData<null>(result));
+        return this.update(id, { name: name });
     };
 
     /**
+     * @deprecated use the update method instead
+     *
      * This method updates the script the action uses by the id and provided script
      * @param id the id of a specific action
      * @param actionScript the JavaScript based action script
      * @returns
      */
     updateScript = async (id: Id, actionScript: string) => {
-        const res = await this.#editorAPI;
-        return res.updateActionScript(id, actionScript).then((result) => getEditorResponseData<null>(result));
+        return this.update(id, { script: actionScript });
     };
 
     /**
+     * @deprecated use the update method instead
+     *
      * This method updates the triggers on which the action will react.
      * @param id the id of a specific action
      * @param triggers the triggers this action should react on.
      * @returns
      */
     updateTriggers = async (id: Id, triggers: ActionTrigger[]) => {
-        const res = await this.#editorAPI;
-        return res
-            .updateActionTriggers(id, JSON.stringify(triggers))
-            .then((result) => getEditorResponseData<null>(result));
+        return this.update(id, { triggers: triggers });
     };
 
     /**
@@ -114,6 +126,8 @@ export class ActionController {
     };
 
     /**
+     * @deprecated use the update method instead
+     *
      * This method stores the state of action type errors to the document
      *
      * Those errors states can be read back from the usual getters or the
@@ -123,7 +137,6 @@ export class ActionController {
      * @returns
      */
     setTypeError = async (id: string, hasTypeErrors: boolean) => {
-        const res = await this.#editorAPI;
-        return res.setActionTypeError(id, hasTypeErrors).then((result) => getEditorResponseData<null>(result));
+        return this.update(id, { hasTypeError: hasTypeErrors });
     };
 }

--- a/packages/sdk/src/tests/controllers/ActionController.test.ts
+++ b/packages/sdk/src/tests/controllers/ActionController.test.ts
@@ -1,4 +1,4 @@
-import { ActionEditorEvent, ActionTrigger } from '../../types/ActionTypes';
+import { ActionDeltaUpdate, ActionEditorEvent, ActionTrigger } from '../../types/ActionTypes';
 import { EditorAPI } from '../../types/CommonTypes';
 import { ActionController } from '../../controllers/ActionController';
 import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorResponseData';
@@ -12,6 +12,7 @@ const mockEditorApi: EditorAPI = {
     duplicateAction: async () => getEditorResponseData(castToEditorResponse(null)),
     removeAction: async () => getEditorResponseData(castToEditorResponse(null)),
     renameAction: async () => getEditorResponseData(castToEditorResponse(null)),
+    updateAction: async () => getEditorResponseData(castToEditorResponse(null)),
     updateActionScript: async () => getEditorResponseData(castToEditorResponse(null)),
     updateActionTriggers: async () => getEditorResponseData(castToEditorResponse(null)),
     moveActions: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -26,10 +27,15 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'duplicateAction');
     jest.spyOn(mockEditorApi, 'removeAction');
     jest.spyOn(mockEditorApi, 'renameAction');
+    jest.spyOn(mockEditorApi, 'updateAction');
     jest.spyOn(mockEditorApi, 'updateActionScript');
     jest.spyOn(mockEditorApi, 'updateActionTriggers');
     jest.spyOn(mockEditorApi, 'moveActions');
     jest.spyOn(mockEditorApi, 'setActionTypeError');
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
 });
 
 afterAll(() => {
@@ -64,15 +70,37 @@ describe('Should call all of the ActionController functions of child successfull
     });
 
     it('should call renameAction function of EditorAPI with the provided params', async () => {
-        await mockedActionController.rename('0', 'new name');
-        expect(mockEditorApi.renameAction).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.renameAction).toHaveBeenCalledWith('0', 'new name');
+        const name = 'new name';
+        const update: ActionDeltaUpdate = {
+            name: name,
+        };
+        await mockedActionController.rename('0', name);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledWith('0', JSON.stringify(update));
     });
 
     it('should call removeAction function of EditorAPI', async () => {
         await mockedActionController.remove('0');
         expect(mockEditorApi.removeAction).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.removeAction).toHaveBeenCalledWith('0');
+    });
+
+    it('should call updateAction function of EditorAPI', async () => {
+        const update: ActionDeltaUpdate = {
+            script: '',
+            name: '',
+            hasTypeError: true,
+            triggers: [
+                {
+                    event: ActionEditorEvent.frameMoved,
+                    triggers: ['1', '2'],
+                },
+            ],
+        };
+
+        await mockedActionController.update('0', update);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledWith('0', JSON.stringify(update));
     });
 
     it('should call updateActionTriggers function of EditorAPI', async () => {
@@ -82,17 +110,23 @@ describe('Should call all of the ActionController functions of child successfull
                 triggers: ['1', '2'],
             },
         ];
+        const update: ActionDeltaUpdate = {
+            triggers: triggers,
+        };
 
         await mockedActionController.updateTriggers('0', triggers);
-        expect(mockEditorApi.updateActionTriggers).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.updateActionTriggers).toHaveBeenCalledWith('0', JSON.stringify(triggers));
+        expect(mockEditorApi.updateAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledWith('0', JSON.stringify(update));
     });
 
-    it('should call updateActionScript function of EditorAPI', async () => {
+    it('should call updateAction function of EditorAPI', async () => {
         const script = 'let a = 1';
+        const update: ActionDeltaUpdate = {
+            script: script,
+        };
         await mockedActionController.updateScript('0', script);
-        expect(mockEditorApi.updateActionScript).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.updateActionScript).toHaveBeenCalledWith('0', script);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledWith('0', JSON.stringify(update));
     });
 
     it('should call moveActions function of EditorAPI', async () => {
@@ -103,9 +137,12 @@ describe('Should call all of the ActionController functions of child successfull
         expect(mockEditorApi.moveActions).toHaveBeenCalledWith(order, ids);
     });
 
-    it('should call removeAction function of EditorAPI', async () => {
+    it('should call updateAction function of EditorAPI', async () => {
+        const update: ActionDeltaUpdate = {
+            hasTypeError: true,
+        };
         await mockedActionController.setTypeError('0', true);
-        expect(mockEditorApi.setActionTypeError).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.setActionTypeError).toHaveBeenCalledWith('0', true);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.updateAction).toHaveBeenCalledWith('0', JSON.stringify(update));
     });
 });

--- a/packages/sdk/src/types/ActionTypes.ts
+++ b/packages/sdk/src/types/ActionTypes.ts
@@ -71,6 +71,31 @@ export interface SelectedLayoutChangedTrigger {
     event: ActionEditorEvent.selectedLayoutChanged;
 }
 
+/**
+ * Model to update an Action.
+ */
+export type ActionDeltaUpdate = {
+    /**
+     * The new Action JS script.
+     */
+    script?: string;
+
+    /**
+     * The new name of the Action.
+     */
+    name?: string;
+
+    /**
+     * Whether the Action has any typing errors.
+     */
+    hasTypeError?: boolean;
+
+    /**
+     * The new list of triggers.
+     */
+    triggers?: ActionTrigger[];
+};
+
 export interface FrameMovedTrigger {
     event: ActionEditorEvent.frameMoved;
     /**


### PR DESCRIPTION
This PR adds `SDK.action.updateAction('id', deltaUpdateModel);`

This allows you to update one or more of the following properties at the same time:
- name
- script
- triggers
- hasTypeError

## PR Guidelines

- [X] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [EDT-1139](https://chilipublishintranet.atlassian.net/browse/EDT-1139)


[EDT-1139]: https://chilipublishintranet.atlassian.net/browse/EDT-1139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ