### PR TITLE
[EDT-1251] Add resolved property to image variable model

### DIFF
--- a/packages/sdk/src/tests/controllers/VariableController.test.ts
+++ b/packages/sdk/src/tests/controllers/VariableController.test.ts
@@ -25,7 +25,10 @@ describe('VariableController', () => {
         occurrences: 0,
         value: {
             connectorId: connectorId,
-            assetId: 'assetId',
+            assetId: 'highres-brush.png',
+            resolved: {
+                mediaId: 'resolved-brush-id'
+            }
         },
     };
 

--- a/packages/sdk/src/tests/controllers/VariableController.test.ts
+++ b/packages/sdk/src/tests/controllers/VariableController.test.ts
@@ -27,8 +27,8 @@ describe('VariableController', () => {
             connectorId: connectorId,
             assetId: 'highres-brush.png',
             resolved: {
-                mediaId: 'resolved-brush-id'
-            }
+                mediaId: 'resolved-brush-id',
+            },
         },
     };
 

--- a/packages/sdk/src/types/VariableTypes.ts
+++ b/packages/sdk/src/types/VariableTypes.ts
@@ -1,6 +1,25 @@
 export interface ConnectorImageVariableSource {
     connectorId: string;
+    /** 
+     * The requested asset id or name
+     */
     assetId: string;
+    /** 
+     * If the connector was able to query, this will contain
+     * the actual resolved media Id.
+     */
+    resolved?: ResolvedMedia;
+}
+
+/**
+ * Image variable query lookup result
+ */
+export interface ResolvedMedia {
+    /**
+     * The resolved media Id.
+     * This id can be used to perform the download call.
+     */
+    mediaId: string;
 }
 
 export enum VariableType {

--- a/packages/sdk/src/types/VariableTypes.ts
+++ b/packages/sdk/src/types/VariableTypes.ts
@@ -1,10 +1,10 @@
 export interface ConnectorImageVariableSource {
     connectorId: string;
-    /** 
+    /**
      * The requested asset id or name
      */
     assetId: string;
-    /** 
+    /**
      * If the connector was able to query, this will contain
      * the actual resolved media Id.
      */


### PR DESCRIPTION
This PR adds the resolved `mediaId` to the `ImageVariable` model. This will enable you to retrieve the media Id when only the asset name was set as the image variable value.

## PR Guidelines

- [X] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)
