### PR TITLE
[Fix] Return editor response on `setZoom` call

### DIFF
--- a/packages/sdk/src/controllers/ToolController.ts
+++ b/packages/sdk/src/controllers/ToolController.ts
@@ -54,7 +54,7 @@ export class ToolController {
      * This method sets the used tool to a Zoom tool
      */
     setZoom = async () => {
-        await this.setTool(ToolType.ZOOM);
+        return this.setTool(ToolType.ZOOM);
     };
 
     /**

--- a/packages/sdk/src/tests/controllers/ToolController.test.ts
+++ b/packages/sdk/src/tests/controllers/ToolController.test.ts
@@ -27,49 +27,57 @@ describe('ToolController', () => {
     });
 
     it('sets the pointer tool', async () => {
-        await mockedToolController.setPointer();
+        const response = await mockedToolController.setPointer();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.SELECT);
+        expect(response.success).toBeTruthy();
     });
     it('sets the move tool', async () => {
-        await mockedToolController.setHand();
+        const response = await mockedToolController.setHand();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.HAND);
+        expect(response.success).toBeTruthy();
     });
 
     it('sets the zoom tool', async () => {
-        await mockedToolController.setZoom();
+        const response = await mockedToolController.setZoom();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.ZOOM);
+        expect(response.success).toBeTruthy();
     });
 
     it('sets the text  tool', async () => {
-        await mockedToolController.setTextFrame();
+        const response = await mockedToolController.setTextFrame();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.TEXT_FRAME);
+        expect(response.success).toBeTruthy();
     });
 
     it('sets the image tool', async () => {
-        await mockedToolController.setImageFrame();
+        const response = await mockedToolController.setImageFrame();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.IMAGE_FRAME);
+        expect(response.success).toBeTruthy();
     });
 
     it('sets the shape rect tool', async () => {
-        await mockedToolController.setShapeRect();
+        const response = await mockedToolController.setShapeRect();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.SHAPE_RECT);
+        expect(response.success).toBeTruthy();
     });
 
     it('sets the shape ellipse tool', async () => {
-        await mockedToolController.setShapeEllipse();
+        const response = await mockedToolController.setShapeEllipse();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.SHAPE_ELLIPSE);
+        expect(response.success).toBeTruthy();
     });
 
     it('sets the shape polygon tool', async () => {
-        await mockedToolController.setShapePolygon();
+        const response = await mockedToolController.setShapePolygon();
         expect(mockEditorApi.setTool).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setTool).toHaveBeenCalledWith(ToolType.SHAPE_POLYGON);
+        expect(response.success).toBeTruthy();
     });
 });


### PR DESCRIPTION
This PR returns the `EditorResponse` from the `SDK.tool.setZoom()` call.