### PR TITLE
[Fix] Export LayoutIntent as enum instead of type

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,7 @@ export {
     TweenTypes,
     BasicAnimationsEmphasisStyles,
 } from './types/AnimationTypes';
-export { LayoutType, MeasurementUnit } from './types/LayoutTypes';
+export { LayoutType, MeasurementUnit, LayoutIntent } from './types/LayoutTypes';
 export {
     BlendMode,
     FrameTypeEnum,
@@ -28,7 +28,6 @@ export type {
     LayoutWithFrameProperties,
     LayoutListItemType,
     Layout,
-    LayoutIntent,
 } from './types/LayoutTypes';
 export type {
     FrameLayoutType,


### PR DESCRIPTION
This PR exports LayoutIntent as enum instead of type.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-1560](https://support.chili-publish.com/projects/WRS/issues/WRS-1560)

## Screenshots


[WRS-1560]: https://chilipublishintranet.atlassian.net/browse/WRS-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ