### PR TITLE
[Fix] Rename setLayoutIntent to setIntent

### DIFF
--- a/packages/sdk/src/controllers/LayoutController.ts
+++ b/packages/sdk/src/controllers/LayoutController.ts
@@ -200,7 +200,7 @@ export class LayoutController {
      * @param id the id of a specific layout
      * @param intent the intent that will be used for the layout
      */
-    setLayoutIntent = async (id: Id, intent: LayoutIntent) => {
+    setIntent = async (id: Id, intent: LayoutIntent) => {
         const res = await this.#editorAPI;
         return res.setLayoutIntent(id, intent).then((result) => getEditorResponseData<null>(result));
     };
@@ -208,10 +208,10 @@ export class LayoutController {
     /**
      * This method resets the intent of a specific layout to its original (inherited) value.
      * Note: Calling this on the top layout is not valid
-     * 
+     *
      * @param id The id of the (child) layout to reset the intent for
      */
-    resetLayoutIntent = async (id: Id) => {
+    resetIntent = async (id: Id) => {
         const res = await this.#editorAPI;
         return res.resetLayoutIntent(id).then((result) => getEditorResponseData<null>(result));
     };

--- a/packages/sdk/src/tests/controllers/LayoutController.test.ts
+++ b/packages/sdk/src/tests/controllers/LayoutController.test.ts
@@ -140,11 +140,11 @@ describe('LayoutController', () => {
         expect(mockedEditorApi.getPageSnapshot).toHaveBeenCalledTimes(1);
     });
     it('Should be possible to set the layout intent', async () => {
-        await mockedLayoutController.setLayoutIntent('1', LayoutIntent.print);
+        await mockedLayoutController.setIntent('1', LayoutIntent.print);
         expect(mockedEditorApi.setLayoutIntent).toHaveBeenCalledTimes(1);
     });
     it('Should be possible to reset the layout intent', async () => {
-        await mockedLayoutController.resetLayoutIntent('1');
+        await mockedLayoutController.resetIntent('1');
         expect(mockedEditorApi.resetLayoutIntent).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
This PR aligns with our usual naming.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)