### PR TITLE
[Fix] Add missing AuthCredentialsTypeEnum mapping

### DIFF
--- a/packages/sdk/src/types/ConnectorTypes.ts
+++ b/packages/sdk/src/types/ConnectorTypes.ts
@@ -258,8 +258,8 @@ export class RefreshedAuthCredendentials {
 }
 
 export enum AuthCredentialsTypeEnum {
-    grafxToken,
-    refreshed,
+    grafxToken = 'grafxToken',
+    refreshed = 'refreshed',
 }
 
 export type AuthCredentials = GrafxTokenAuthCredentials | RefreshedAuthCredendentials;


### PR DESCRIPTION
This PR adds a missing mapping for the enum preventing type identification on engine-side.
_Only for Pavel as of now._

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets
None