### PR TITLE
[Breaking] Remove deprecated setChiliToken

### DIFF
--- a/packages/sdk/src/controllers/ConnectorController.ts
+++ b/packages/sdk/src/controllers/ConnectorController.ts
@@ -243,20 +243,6 @@ class ConnectorConfigurator {
     };
 
     /**
-     * @deprecated define the GraFx Studio Auth Token in the `SDK.Configuration.setValue`
-     *
-     * This method sets the GraFx Access Token in the Authentication HTTP header for the 'chili' authentication type.
-     * The CHILI Token will be used to authenticate every grafx connector http call.
-     * @param token token for the CHILI authentication
-     * @returns
-     */
-    setChiliToken = async (token: string) => {
-        return this.#res
-            .connectorAuthenticationSetChiliToken(this.#connectorId, token)
-            .then((result) => getEditorResponseData<null>(result));
-    };
-
-    /**
      * This method sets the HTTP headers for the 'staticKey' authentication type.
      * These additional headers will be added to all connector http calls.
      * Can only be used after a connector has been registered. (if you are using a grafx connector no registration is needed)

--- a/packages/sdk/src/tests/controllers/ConnectorController.test.ts
+++ b/packages/sdk/src/tests/controllers/ConnectorController.test.ts
@@ -17,7 +17,6 @@ const mockEditorApi: EditorAPI = {
     getConnectors: async () => getEditorResponseData(castToEditorResponse(null)),
     registerConnector: async () => getEditorResponseData(castToEditorResponse(null)),
     unregisterConnector: async () => getEditorResponseData(castToEditorResponse(null)),
-    connectorAuthenticationSetChiliToken: async () => getEditorResponseData(castToEditorResponse(null)),
     updateConnectorConfiguration: async () => getEditorResponseData(castToEditorResponse(null)),
     getConnectorState: async () => getEditorResponseData(castToEditorResponse({ id: '', type: 'ready' })),
     connectorAuthenticationSetHttpHeader: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -33,7 +32,6 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'getConnectors');
     jest.spyOn(mockEditorApi, 'registerConnector');
     jest.spyOn(mockEditorApi, 'unregisterConnector');
-    jest.spyOn(mockEditorApi, 'connectorAuthenticationSetChiliToken');
     jest.spyOn(mockEditorApi, 'updateConnectorConfiguration');
     jest.spyOn(mockEditorApi, 'getConnectorState');
     jest.spyOn(mockEditorApi, 'connectorAuthenticationSetHttpHeader');
@@ -115,11 +113,8 @@ describe('ConnectorController', () => {
                 ),
             ]);
             configurator.setOptions({ test: 'data' });
-            configurator.setChiliToken(token);
         });
 
-        expect(mockEditorApi.connectorAuthenticationSetChiliToken).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.connectorAuthenticationSetChiliToken).toHaveBeenCalledWith(connectorId, token);
         expect(mockEditorApi.updateConnectorConfiguration).toHaveBeenCalledTimes(1);
 
         expect(mockEditorApi.connectorAuthenticationSetHttpHeader).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR removes the deprecated `setChiliToken` method

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1034

---

This is flagged as **breaking change** since my ticket was also flagged as such. Still this has been deprecated for a few months now.