### PR TITLE
[Fix] Extend LayoutPropertyNames with bleed property names

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,6 @@ export {
     TweenTypes,
     BasicAnimationsEmphasisStyles,
 } from './types/AnimationTypes';
-export { LayoutType, MeasurementUnit, LayoutIntent, PositionEnum } from './types/LayoutTypes';
 export {
     BlendMode,
     FrameTypeEnum,
@@ -30,6 +29,10 @@ export type {
     LayoutWithFrameProperties,
     LayoutListItemType,
     Layout,
+    LayoutType,
+    MeasurementUnit,
+    LayoutIntent,
+    PositionEnum
 } from './types/LayoutTypes';
 export type {
     FrameLayoutType,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ export {
     TweenTypes,
     BasicAnimationsEmphasisStyles,
 } from './types/AnimationTypes';
+export { LayoutType, MeasurementUnit, LayoutIntent, PositionEnum } from './types/LayoutTypes';
 export {
     BlendMode,
     FrameTypeEnum,
@@ -29,10 +30,6 @@ export type {
     LayoutWithFrameProperties,
     LayoutListItemType,
     Layout,
-    LayoutType,
-    MeasurementUnit,
-    LayoutIntent,
-    PositionEnum
 } from './types/LayoutTypes';
 export type {
     FrameLayoutType,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,7 @@ export {
     TweenTypes,
     BasicAnimationsEmphasisStyles,
 } from './types/AnimationTypes';
-export { LayoutType, MeasurementUnit, LayoutIntent } from './types/LayoutTypes';
+export { LayoutType, MeasurementUnit, LayoutIntent, PositionEnum } from './types/LayoutTypes';
 export {
     BlendMode,
     FrameTypeEnum,

--- a/packages/sdk/src/utils/enums.ts
+++ b/packages/sdk/src/utils/enums.ts
@@ -8,6 +8,11 @@ export enum FramePropertyNames {
 export enum LayoutPropertyNames {
     LAYOUT_HEIGHT = 'layoutHeight',
     LAYOUT_WIDTH = 'layoutWidth',
+    BLEED_TOP = 'bleedTop',
+    BLEED_BOTTOM = 'bleedBottom',
+    BLEED_LEFT = 'bleedLeft',
+    BLEED_RIGHT = 'bleedRight',
+    BLEED_VALUES_COMBINED = 'areBleedValuesCombined',
 }
 
 export enum ToolType {


### PR DESCRIPTION
This PR extends LayoutPropertyNames with bleed property names

## PR Guidelines

- [ ] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-1579](https://support.chili-publish.com/projects/WRS/issues/WRS-1579)

## Screenshots


[WRS-1579]: https://chilipublishintranet.atlassian.net/browse/WRS-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ