### PR TITLE
[Feature] Allow barcode frame sources to receive null as a source

### DIFF
--- a/packages/sdk/src/controllers/BarcodeController.ts
+++ b/packages/sdk/src/controllers/BarcodeController.ts
@@ -92,10 +92,19 @@ export class BarcodeController {
      * @param source the new source that you want to set to the barcodeFrame.
      * @returns
      */
-    setBarcodeSource = async (id: Id, source: BarcodeSource | null) => {
+    setBarcodeSource = async (id: Id, source: BarcodeSource) => {
         const res = await this.#editorAPI;
-        const srcJson = source !== null ? JSON.stringify(source) : null;
-        return res.setBarcodeSource(id, srcJson).then((result) => getEditorResponseData<null>(result));
+        return res.setBarcodeSource(id, JSON.stringify(source) ).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * @experimental This method will remove the source from the barcode frame provided.
+     * @param id the id of the barcodeFrame that needs to have the source removed.
+     * @returns
+     */
+    removeBarcodeSource = async (id: Id) => {
+        const res = await this.#editorAPI;
+        return res.setBarcodeSource(id, null).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/packages/sdk/src/controllers/BarcodeController.ts
+++ b/packages/sdk/src/controllers/BarcodeController.ts
@@ -92,7 +92,7 @@ export class BarcodeController {
      * @param source the new source that you want to set to the barcodeFrame.
      * @returns
      */
-    setBarcodeSource = async (id: Id, source: BarcodeSource) => {
+    setBarcodeSource = async (id: Id, source: BarcodeSource | null) => {
         const res = await this.#editorAPI;
         return res.setBarcodeSource(id, JSON.stringify(source)).then((result) => getEditorResponseData<null>(result));
     };

--- a/packages/sdk/src/controllers/BarcodeController.ts
+++ b/packages/sdk/src/controllers/BarcodeController.ts
@@ -94,7 +94,8 @@ export class BarcodeController {
      */
     setBarcodeSource = async (id: Id, source: BarcodeSource | null) => {
         const res = await this.#editorAPI;
-        return res.setBarcodeSource(id, JSON.stringify(source)).then((result) => getEditorResponseData<null>(result));
+        const srcJson = source !== null ? JSON.stringify(source) : null;
+        return res.setBarcodeSource(id, srcJson).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/packages/sdk/src/tests/controllers/BarcodeController.test.ts
+++ b/packages/sdk/src/tests/controllers/BarcodeController.test.ts
@@ -148,7 +148,7 @@ describe('BarcodeController', () => {
             const source: BarcodeSource = { type: BarcodeSourceTypeEnum.text, text: 'test' };
             await mockedBarcodeController.setBarcodeSource(id, source);
             await mockedBarcodeController.removeBarcodeSource(id);
-            expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalled();
+            expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledTimes(2);
             expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledWith(id, null);
         });
     });

--- a/packages/sdk/src/tests/controllers/BarcodeController.test.ts
+++ b/packages/sdk/src/tests/controllers/BarcodeController.test.ts
@@ -12,6 +12,7 @@ let id: Id;
 let mockedBarcodeController: BarcodeController;
 
 const mockedEditorApi: EditorAPI = {
+    removeBarcodeSource: async () => getEditorResponseData(castToEditorResponse(null)),
     setBarcodeProperties: async () => getEditorResponseData(castToEditorResponse(null)),
     setBarcodeSource: async () => getEditorResponseData(castToEditorResponse(null)),
 };
@@ -140,6 +141,15 @@ describe('BarcodeController', () => {
             await mockedBarcodeController.setBarcodeSource(id, source);
             expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledTimes(2);
             expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledWith(id, JSON.stringify(source));
+        });
+    });
+    describe('removeBarcodeSource', () => {
+        it('Should be possible to remove the source', async () => {
+            const source: BarcodeSource = { type: BarcodeSourceTypeEnum.text, text: 'test' };
+            await mockedBarcodeController.setBarcodeSource(id, source);
+            await mockedBarcodeController.removeBarcodeSource(id);
+            expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalled();
+            expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledWith(id, null);
         });
     });
     describe('getBarcodeConfigurationOptions', () => {

--- a/packages/sdk/src/tests/controllers/BarcodeController.test.ts
+++ b/packages/sdk/src/tests/controllers/BarcodeController.test.ts
@@ -148,7 +148,7 @@ describe('BarcodeController', () => {
             const source: BarcodeSource = { type: BarcodeSourceTypeEnum.text, text: 'test' };
             await mockedBarcodeController.setBarcodeSource(id, source);
             await mockedBarcodeController.removeBarcodeSource(id);
-            expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledTimes(2);
+            expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledTimes(4);
             expect(mockedEditorApi.setBarcodeSource).toHaveBeenCalledWith(id, null);
         });
     });


### PR DESCRIPTION
This PR allows barcode frame sources to receive null as a source.

## PR Guidelines

- [ ] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-1644](https://support.chili-publish.com/projects/WRS/issues/WRS-1644)

## Screenshots


[WRS-1644]: https://chilipublishintranet.atlassian.net/browse/WRS-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ