### PR TITLE
[Feature] [EDT-1465] Allow reordering character styles

### DIFF
--- a/packages/sdk/src/controllers/CharacterStyleController.ts
+++ b/packages/sdk/src/controllers/CharacterStyleController.ts
@@ -94,4 +94,15 @@ export class CharacterStyleController {
             .renameCharacterStyle(characterStyleId, characterStyleName)
             .then((result) => getEditorResponseData<null>(result));
     };
+
+    /**
+     * This method changes positions of character styles
+     * @param order the position of the character styles
+     * @param ids the list of character style ids
+     * @returns
+     */
+    move = async (order: number, ids: Id[]) => {
+        const res = await this.#editorAPI;
+        return res.moveCharacterStyles(order, ids).then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/packages/sdk/src/controllers/ParagraphStyleController.ts
+++ b/packages/sdk/src/controllers/ParagraphStyleController.ts
@@ -94,10 +94,10 @@ export class ParagraphStyleController {
     /**
      * This method changes positions of paragraph styles
      * @param order the position of the paragraph styles
-     * @param ids the list of paragraph styles ids
+     * @param ids the list of paragraph style ids
      * @returns
      */
-    move = async (order: number, ids: string[]) => {
+    move = async (order: number, ids: Id[]) => {
         const res = await this.#editorAPI;
         return res.moveParagraphStyles(order, ids).then((result) => getEditorResponseData<null>(result));
     };

--- a/packages/sdk/src/tests/controllers/CharacterStyleController.test.ts
+++ b/packages/sdk/src/tests/controllers/CharacterStyleController.test.ts
@@ -14,6 +14,7 @@ const mockEditorApi: EditorAPI = {
     updateCharacterStyle: async () => getEditorResponseData(castToEditorResponse(null)),
     duplicateCharacterStyle: async () => getEditorResponseData(castToEditorResponse(null)),
     renameCharacterStyle: async () => getEditorResponseData(castToEditorResponse(null)),
+    moveCharacterStyles: async () => getEditorResponseData(castToEditorResponse(null)),
     removeCharacterStyle: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
@@ -24,6 +25,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'createCharacterStyle');
     jest.spyOn(mockEditorApi, 'updateCharacterStyle');
     jest.spyOn(mockEditorApi, 'duplicateCharacterStyle');
+    jest.spyOn(mockEditorApi, 'moveCharacterStyles');
     jest.spyOn(mockEditorApi, 'renameCharacterStyle');
     jest.spyOn(mockEditorApi, 'removeCharacterStyle');
 });
@@ -119,6 +121,12 @@ describe('CharacterStyleController', () => {
         await mockedCharacterStyleController.duplicate('6');
         expect(mockEditorApi.duplicateCharacterStyle).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.duplicateCharacterStyle).toHaveBeenCalledWith('6');
+    });
+
+    it('Should call the moveCharacterStyles method', async () => {
+        await mockedCharacterStyleController.move(2, ['1', '2']);
+        expect(mockEditorApi.moveCharacterStyles).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.moveCharacterStyles).toHaveBeenCalledWith(2, ['1', '2']);
     });
 
     it('Should call the renameCharacterStyle method', async () => {


### PR DESCRIPTION
This PR adds the missing `move` method on `CharacterStyleController`. 

## PR Guidelines

- [X] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)
