### PR TITLE
[Fix] Fix list variables 

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -147,7 +147,8 @@ export class SDK {
                 onFrameAnimationsChanged: this.subscriber.onAnimationChanged,
                 onVariableListChanged: (state) => {
                     this.subscriber.onVariableListChanged(state);
-                    this.next.subscriber.onVariableListChanged(state);
+                    // TODO: to be revisited after the release as it overrides the variables list
+                    // this.next.subscriber.onVariableListChanged(state);
                 },
                 onSelectedToolChanged: this.subscriber.onSelectedToolChanged,
                 onUndoStateChanged: this.subscriber.onUndoStateChanged,


### PR DESCRIPTION
This PR comments out the `next.subscriber.onVariableListChanged` as it overrides the variables list which currently breaks the studio workspace and studio ui

## PR Guidelines

- [ ] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-NUMBER](https://support.chili-publish.com/projects/WRS/issues/WRS-NUMBER)

## Screenshots
