### PR TITLE
[FEATURE] Strict typings on connectors mapping

### DIFF
--- a/packages/sdk/src/controllers/ConnectorController.ts
+++ b/packages/sdk/src/controllers/ConnectorController.ts
@@ -2,7 +2,6 @@ import { ConnectorOptions, EditorAPI, EditorResponse, Id } from '../types/Common
 import {
     ConnectorState,
     ConnectorStateType,
-    ConnectorMapping,
     ConnectorMappingType,
     ConnectorRegistration,
     ConnectorInstance,

--- a/packages/sdk/src/controllers/ConnectorController.ts
+++ b/packages/sdk/src/controllers/ConnectorController.ts
@@ -3,6 +3,7 @@ import {
     ConnectorState,
     ConnectorStateType,
     ConnectorMapping,
+    ConnectorMappingType,
     ConnectorRegistration,
     ConnectorInstance,
     ConnectorType,
@@ -113,7 +114,7 @@ export class ConnectorController {
      */
     getMappings = async (id: string) => {
         const res = await this.#editorAPI;
-        return res.getConnectorMappings(id).then((result) => getEditorResponseData<ConnectorMapping[]>(result));
+        return res.getConnectorMappings(id).then((result) => getEditorResponseData<ConnectorMappingType[]>(result));
     };
 
     /**
@@ -232,7 +233,7 @@ class ConnectorConfigurator {
      * @param mappings collection of mappings to set to this connector
      * @returns
      */
-    setMappings = async (mappings: ConnectorMapping[]) => {
+    setMappings = async (mappings: ConnectorMappingType[]) => {
         const result = await this.#res.setConnectorMappings(
             this.#connectorId,
             mappings.map(function (m) {

--- a/packages/sdk/src/controllers/ConnectorController.ts
+++ b/packages/sdk/src/controllers/ConnectorController.ts
@@ -129,17 +129,14 @@ export class ConnectorController {
         return res
             .getConnectorMappings(id)
             .then((result) => getEditorResponseData<ConnectorMappingType[]>(result))
-            .then((result) => {
-                if (!direction) {
-                    return result;
-                }
-                if (direction) {
-                    return {
-                        ...result,
-                        parsedData: result.parsedData?.filter((cm) => cm.direction === direction),
-                    };
-                }
-            });
+            .then((result) =>
+                !direction
+                    ? result
+                    : {
+                          ...result,
+                          parsedData: result.parsedData?.filter((cm) => cm.direction === direction),
+                      },
+            );
     }
 
     /**

--- a/packages/sdk/src/tests/controllers/ConnectorController.test.ts
+++ b/packages/sdk/src/tests/controllers/ConnectorController.test.ts
@@ -5,9 +5,11 @@ import {
     ConnectorMappingSource,
     ConnectorRegistration,
     ConnectorRegistrationSource,
+    ConnectorToEngineMapping,
     ConnectorType,
+    EngineToConnectorMapping,
 } from '../../types/ConnectorTypes';
-import { EditorAPI } from '../../types/CommonTypes';
+import { EditorAPI, EditorResponse } from '../../types/CommonTypes';
 import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorResponseData';
 
 let mockedConnectorController: ConnectorController;
@@ -96,6 +98,52 @@ describe('ConnectorController', () => {
         await mockedConnectorController.getMappings(connectorId);
         expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledWith(connectorId);
+    });
+
+    it('Should be possible to get typed "EngineToConnector" connector mappings', async () => {
+        (mockEditorApi.getConnectorMappings as jest.Mock).mockResolvedValueOnce({
+            success: true,
+            data: JSON.stringify([
+                {
+                    direction: ConnectorMappingDirection.connectorToEngine,
+                },
+                {
+                    direction: ConnectorMappingDirection.engineToConnector,
+                },
+            ]),
+        });
+        const result: EditorResponse<EngineToConnectorMapping[]> = await mockedConnectorController.getMappings(
+            connectorId,
+            ConnectorMappingDirection.engineToConnector,
+        );
+        expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledWith(connectorId);
+        expect(
+            result.parsedData?.every((r) => r.direction === ConnectorMappingDirection.engineToConnector),
+        ).toBeTruthy();
+    });
+
+    it('Should be possible to get typed "ConnectorToEngine" connector mappings', async () => {
+        (mockEditorApi.getConnectorMappings as jest.Mock).mockResolvedValueOnce({
+            success: true,
+            data: JSON.stringify([
+                {
+                    direction: ConnectorMappingDirection.connectorToEngine,
+                },
+                {
+                    direction: ConnectorMappingDirection.engineToConnector,
+                },
+            ]),
+        });
+        const result: EditorResponse<ConnectorToEngineMapping[]> = await mockedConnectorController.getMappings(
+            connectorId,
+            ConnectorMappingDirection.connectorToEngine,
+        );
+        expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.getConnectorMappings).toHaveBeenCalledWith(connectorId);
+        expect(
+            result.parsedData?.every((r) => r.direction === ConnectorMappingDirection.connectorToEngine),
+        ).toBeTruthy();
     });
 
     it('Should be possible to configure a connector', async () => {

--- a/packages/sdk/src/tests/controllers/ConnectorController.test.ts
+++ b/packages/sdk/src/tests/controllers/ConnectorController.test.ts
@@ -104,6 +104,7 @@ describe('ConnectorController', () => {
             configurator.setMappings([
                 new ConnectorMapping('data', ConnectorMappingSource.variable, '6B29FC40-CA47-1067-B31D-00DD010662DA'),
                 new ConnectorMapping('plain', ConnectorMappingSource.value, 'plain value'),
+                new ConnectorMapping('switch', ConnectorMappingSource.value, true),
                 new ConnectorMapping(
                     'price',
                     ConnectorMappingSource.variable,
@@ -131,6 +132,7 @@ describe('ConnectorController', () => {
                 value: 'var.6B29FC40-CA47-1067-B31D-00DD010662DA',
             }),
             JSON.stringify({ direction: 'engineToConnector', name: 'plain', value: 'plain value' }),
+            JSON.stringify({ direction: 'engineToConnector', name: 'switch', value: true }),
             JSON.stringify({
                 direction: 'connectorToEngine',
                 name: 'price',

--- a/packages/sdk/src/types/ConnectorTypes.ts
+++ b/packages/sdk/src/types/ConnectorTypes.ts
@@ -109,10 +109,24 @@ export enum ConnectorRegistrationSource {
     local = 'local',
 }
 
-export class ConnectorMapping {
+export interface EngineToConnectorMapping {
     name: string;
     value: string | boolean;
-    direction = ConnectorMappingDirection.engineToConnector;
+    direction: ConnectorMappingDirection.engineToConnector;
+}
+
+export interface ConnectorToEngineMapping {
+    name: string;
+    value: string;
+    direction: ConnectorMappingDirection.connectorToEngine;
+}
+
+export type ConnectorMappingType = EngineToConnectorMapping | ConnectorToEngineMapping;
+
+export class ConnectorMapping implements EngineToConnectorMapping, ConnectorToEngineMapping {
+    name: string;
+    value: any;
+    direction: any = ConnectorMappingDirection.engineToConnector;
 
     constructor(
         contextProperty: string,

--- a/packages/sdk/src/types/ConnectorTypes.ts
+++ b/packages/sdk/src/types/ConnectorTypes.ts
@@ -125,7 +125,9 @@ export type ConnectorMappingType = EngineToConnectorMapping | ConnectorToEngineM
 
 export class ConnectorMapping implements EngineToConnectorMapping, ConnectorToEngineMapping {
     name: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     direction: any = ConnectorMappingDirection.engineToConnector;
 
     constructor(

--- a/packages/sdk/src/types/ConnectorTypes.ts
+++ b/packages/sdk/src/types/ConnectorTypes.ts
@@ -130,6 +130,19 @@ export class ConnectorMapping implements EngineToConnectorMapping, ConnectorToEn
 
     constructor(
         contextProperty: string,
+        mapFrom: ConnectorMappingSource.variable,
+        sourceValue: string,
+        direction: ConnectorMappingDirection.connectorToEngine,
+    );
+    constructor(
+        contextProperty: string,
+        mapFrom: ConnectorMappingSource,
+        sourceValue: string | boolean,
+        direction?: ConnectorMappingDirection.engineToConnector,
+    );
+    constructor(contextProperty: string, mapFrom: ConnectorMappingSource, sourceValue: string | boolean);
+    constructor(
+        contextProperty: string,
         mapFrom: ConnectorMappingSource,
         sourceValue: string | boolean,
         direction = ConnectorMappingDirection.engineToConnector,


### PR DESCRIPTION
This PR adds type safety when working with ConnectorMapping. It also adds possibility to retrieve specified mapping for provided direction (with again type safety around `value` field)

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)