### PR TITLE
[Fix] NextInitiator and Controllers not in docs

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -25,6 +25,8 @@
             // Alphabetically!!
             "src/index.ts",
             "src/controllers/*.ts",
+            "src/next/controllers/*.ts",
+            "src/next/NextInitiator.ts",
             "src/types/*.ts"
         ],
         "out": "docs",


### PR DESCRIPTION
This PR adds the NextInitiator and controllers to the docs

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-1983](https://support.chili-publish.com/projects/WRS/issues/WRS-1983)
