### PR TITLE
[Feature] Support required variables

### DIFF
--- a/packages/sdk/src/controllers/VariableController.ts
+++ b/packages/sdk/src/controllers/VariableController.ts
@@ -620,6 +620,27 @@ export class VariableController {
         return res.getVariablePrivateData(id).then((result) => getEditorResponseData<PrivateData>(result));
     };
 
+    /**
+     * Gets the variables having required values that are not set
+     *
+     * PDF output won't work if all required variables are not set
+     *
+     * @returns the list of invalid variables
+     */
+    getAllRequiredAndInvalid = async () => {
+        const res = await this.#editorAPI;
+        return res
+            .getInvalidRequiredVariables()
+            .then((result) => getEditorResponseData<Variable[]>(result))
+            .then((resp) => {
+                const update = resp;
+                if (update.parsedData) {
+                    update.parsedData = this.makeVariablesBackwardsCompatible(update.parsedData);
+                }
+                return update;
+            });
+    };
+
     private makeVariablesBackwardsCompatible(variables: Variable[]) {
         return variables.map((variable) => {
             return this.makeVariableBackwardsCompatible(variable);

--- a/packages/sdk/src/tests/controllers/VariableController.test.ts
+++ b/packages/sdk/src/tests/controllers/VariableController.test.ts
@@ -57,7 +57,22 @@ describe('VariableController', () => {
         privateData: {},
     };
 
+    const listVar2: Variable & { items: ListVariableItem[]; selected?: ListVariableItem } = {
+        id: variableId,
+        type: VariableType.list,
+        name: '',
+        label: '',
+        isVisible: true,
+        isReadonly: false,
+        isRequired: true,
+        occurrences: 0,
+        selected: undefined,
+        items: [{ value: 'def', displayValue: 'D-E-F' }],
+        privateData: {},
+    };
+
     const variables = [listVar];
+    const invalidVariables = [listVar2];
 
     const mockEditorApi: EditorAPI = {
         getVariableById: async () => getEditorResponseData(castToEditorResponse(variable)),
@@ -88,6 +103,7 @@ describe('VariableController', () => {
         updateVariablePrefixSuffixProperties: async () => getEditorResponseData(castToEditorResponse(null)),
         setVariablePrivateData: async () => getEditorResponseData(castToEditorResponse(null)),
         getVariablePrivateData: async () => getEditorResponseData(castToEditorResponse(privateData)),
+        getInvalidRequiredVariables: async () => getEditorResponseData(castToEditorResponse(invalidVariables)),
     };
 
     beforeEach(() => {
@@ -120,6 +136,7 @@ describe('VariableController', () => {
         jest.spyOn(mockEditorApi, 'updateVariablePrefixSuffixProperties');
         jest.spyOn(mockEditorApi, 'setVariablePrivateData');
         jest.spyOn(mockEditorApi, 'getVariablePrivateData');
+        jest.spyOn(mockEditorApi, 'getInvalidRequiredVariables');
     });
 
     it('get variable by id', async () => {
@@ -488,5 +505,13 @@ describe('VariableController', () => {
         expect(mockEditorApi.getVariablePrivateData).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getVariablePrivateData).toHaveBeenCalledWith('1');
         expect(response?.parsedData).toStrictEqual(privateData);
+    });
+
+    it('get invalid required variable list', async () => {
+        const result = await mockedVariableController.getAllRequiredAndInvalid();
+        expect(mockEditorApi.getInvalidRequiredVariables).toHaveBeenCalledTimes(1);
+        // Backwards compatibility layer maps the new `VariableListItem` into a string.
+        expect((result.parsedData as ListVariable[])[0].items).toStrictEqual(['def']);
+        expect((result.parsedData as ListVariable[])[0].selected).toStrictEqual(undefined);
     });
 });


### PR DESCRIPTION
This PR supports the required variables behavior and add a new getter to the variable controller: `getAllRequiredAndInvalid`.

_In doubts about the name.._

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1607
