### PR TITLE
[Fix] Throw a ConnectorHttpError when the engine error code matches

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,7 @@
 import { SDK } from './sdk';
 
 export { FramePropertyNames, LayoutPropertyNames, ToolType, DownloadFormats, EnvironmentType } from './utils/enums';
+export { ConnectorHttpError } from './utils/EditorResponseData';
 
 export {
     SlideDirections,

--- a/packages/sdk/src/tests/utils/editorResponseData.test.ts
+++ b/packages/sdk/src/tests/utils/editorResponseData.test.ts
@@ -1,4 +1,5 @@
-import { castToEditorResponse } from '../../utils/EditorResponseData';
+import { EditorResponse } from '../../types/CommonTypes';
+import { castToEditorResponse, ConnectorHttpError, getEditorResponseData } from '../../utils/EditorResponseData';
 
 const partialMockResult = {
     status: 200,
@@ -52,6 +53,63 @@ describe('EditorResponseData Util(s)', () => {
             const result = castToEditorResponse(toCast);
 
             expect(result).toMatchObject({ ...partialMockResult, data: '[{"a":"b","c":"d"},{"e":3}]' });
+        });
+    });
+
+    describe('getEditorResponseData', () => {
+        const mockErrorResponse: EditorResponse<null> = {
+            status: 12345, // Dummy engine error code
+            success: false,
+            error: 'engine error',
+            data: '',
+            parsedData: null,
+        };
+
+        it('should throw ConnectorHttpError when status matches connectorHttpErrorErrorCode', () => {
+            // Do NOT use the value from EditorResponseData file as it will make sure
+            // any misalignment with SDK and/or engine is reported.
+            const connectorHttpErrorErrorCode = 404075;
+            const httpRequestErrorCode = 500;
+            const errorMessage = 'Dummy http error message';
+
+            const response = {
+                ...mockErrorResponse,
+                status: connectorHttpErrorErrorCode,
+                error: errorMessage,
+                data: JSON.stringify({ statusCode: httpRequestErrorCode }),
+            };
+
+            expect(() => getEditorResponseData(response)).toThrowError(ConnectorHttpError);
+
+            try {
+                getEditorResponseData(response);
+            } catch (error) {
+                expect(error).toBeInstanceOf(ConnectorHttpError);
+                expect((error as ConnectorHttpError).statusCode).toBe(httpRequestErrorCode); // or whatever the httpStatusCode is
+                expect((error as ConnectorHttpError).message).toBe(errorMessage);
+
+                const cause = (error as Error).cause as { name: string; message: string };
+                expect(cause.name).toBe(connectorHttpErrorErrorCode.toString());
+                expect(cause.message).toBe(errorMessage);
+            }
+        });
+
+        it('should throw a simple Error when status does NOT match connectorHttpErrorErrorCode', () => {
+            const response = mockErrorResponse;
+
+            expect(() => getEditorResponseData(response)).toThrowError(Error);
+
+            try {
+                getEditorResponseData(response);
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect(error).not.toBeInstanceOf(ConnectorHttpError);
+                expect((error as Error).message).toBe(mockErrorResponse.error);
+
+                const cause = (error as Error).cause as { name: string; message: string };
+                expect(cause.name).toBe(mockErrorResponse.status.toString());
+                expect(cause.message).toBe(mockErrorResponse.error);
+            }
         });
     });
 });


### PR DESCRIPTION
This PR will throw a `ConnectorHttpError` instead of a generic `Error` whenever an http request from the connector fails. The http status code will be reported into the new error type.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://github.com/chili-publish/studio-engine/pull/1476

🔓 Unblocks https://chilipublishintranet.atlassian.net/browse/WRS-2002
