### PR TITLE
ColorUsageType is not exported as usable enum

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -54,14 +54,14 @@ export type {
     AutoGrowSettings,
     AnchorTarget,
     FrameAnchor,
-    PageAnchorTarget,
-    FrameAnchorTarget,
     RelativeFrameAnchor,
     StartFrameAnchor,
     EndFrameAnchor,
     StartAndEndFrameAnchor,
     CenterFrameAnchor
 } from './types/FrameTypes';
+export { PageAnchorTarget, FrameAnchorTarget } from './types/FrameTypes';
+
 export type {
     Variable,
     GroupVariable,
@@ -102,8 +102,8 @@ export type {
     Id,
     ConnectorConfigOptions,
     ConnectorConfigValue,
-    ConnectorConfigValueType,
 } from './types/CommonTypes';
+export { ConnectorConfigValueType } from './types/CommonTypes';
 
 export type {
     TextProperties,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -117,7 +117,8 @@ export type {
 
 export type { ParagraphStyle, ParagraphStyleUpdate } from './types/ParagraphStyleTypes';
 export type { CharacterStyle, CharacterStyleUpdate } from './types/CharacterStyleTypes';
-export type { ColorUsage, ColorUsageUpdate, ColorUsageType } from './types/ColorStyleTypes';
+export type { ColorUsage, ColorUsageUpdate } from './types/ColorStyleTypes';
+export { ColorUsageType } from './types/ColorStyleTypes';
 
 export type {
     DocumentFontStyle,


### PR DESCRIPTION
This fixes the export for ColorUsageType, and other `enum` or `class` types that are exported as TypeAlias.
`
Example where it goes wrong:

```ts
(async () => {
    // Fetch all frames to find the ID of the frame named 'InventoryBarcode'
    const framesResponse = await window.SDK.frame.getAll();
    const frames = framesResponse.parsedData;
    // Find the frame with name 'InventoryBarcode', case insensitive
    const inventoryBarcodeFrame = frames.find(frame => frame.name.toLowerCase() === 'inventorybarcode');
    if (!inventoryBarcodeFrame) {
        throw new Error("Frame 'InventoryBarcode' not found");
    }
 
    const frameId = inventoryBarcodeFrame.id;
 
    // Define the custom hex color
    const backgroundColor: ColorUsage = {
        color: {
            value: '#FF5733',
            type: ColorType.hex
        },
        type: ColorUsageType.local
    };
 
    // Set the background color of the 'InventoryBarcode' frame
    await window.SDK.barcode.setBackgroundColor(frameId, backgroundColor);
})();
```

throws errors like

`'ColorUsageType' cannot be used as a value because it was exported using 'export type'.`


For reference, this is the script used to find all offenders:

```ts
import { Project, SyntaxKind } from "ts-morph";

const project = new Project({
  tsConfigFilePath: "./clones/studio-sdk/packages/sdk/tsconfig.json",
});

const sourceFile = project.getSourceFileOrThrow("index.ts");
const allDeclarations = sourceFile.getExportedDeclarations();

sourceFile.getDescendantsOfKind(SyntaxKind.ExportDeclaration).forEach((e) => {
  const exportListIsTypeOnly = e.isTypeOnly();
  e.getNamedExports().forEach((n) => {
    // used to resolve the name of the export in the declarations map
    const exportName = n.getAliasNode()?.getText() ?? n.getName();
    const exportIsTypeOnly = n.isTypeOnly();

    allDeclarations.get(exportName)?.forEach((d) => {
      // type only exports must be type aliases
      if (d.getKind() !== SyntaxKind.TypeAliasDeclaration && (exportListIsTypeOnly || exportIsTypeOnly)) {
        console.error(`'${n.getText()}' at ${n.compilerNode.getFullStart()}, ${n.compilerNode.getEnd()} is type only but is not a type alias (${d.getKindName()})`);
      }
    });
  });
});
```
