### PR TITLE
[EDT-1808] expose deselectAll() method

### DIFF
--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -173,6 +173,15 @@ export class FrameController {
     };
 
     /**
+     * This method will deselect all frames
+     * @returns
+     */
+    deselectAll = async () => {
+        const res = await this.#editorAPI;
+        return res.deselectFrames().then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
      * This method changes the order of frames in the z-index list.
      * @param order the index in the list to move to
      * @param ids An array of all IDs you want to move to the given index
@@ -502,9 +511,11 @@ export class FrameController {
      */
     setImageFrameFitModePosition = async (imageFrameId: Id, position: FitModePosition) => {
         const res = await this.#editorAPI;
-        return res.setImageFrameFitModePosition(imageFrameId, position).then((result) => getEditorResponseData<null>(result));
+        return res
+            .setImageFrameFitModePosition(imageFrameId, position)
+            .then((result) => getEditorResponseData<null>(result));
     };
-    
+
     /**
      * @deprecated the constrain proportions setter is not supported anymore.
      *
@@ -699,8 +710,6 @@ export class FrameController {
 
         return getEditorResponseData<null>(res);
     };
-
-    
 
     /**
      * This method will exit cropping mode without saving the applied crop.

--- a/packages/sdk/src/tests/controllers/FrameController.test.ts
+++ b/packages/sdk/src/tests/controllers/FrameController.test.ts
@@ -51,6 +51,7 @@ const mockedEditorApi: EditorAPI = {
     removeImageSource: async () => getEditorResponseData(castToEditorResponse(null)),
     selectFrames: async () => getEditorResponseData(castToEditorResponse(null)),
     selectMultipleFrames: async () => getEditorResponseData(castToEditorResponse(null)),
+    deselectFrames: async () => getEditorResponseData(castToEditorResponse(null)),
     setFrameName: async () => getEditorResponseData(castToEditorResponse(null)),
     setImageFrameFitMode: async () => getEditorResponseData(castToEditorResponse(null)),
     setImageFrameFitModePosition: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -101,6 +102,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'removeImageSource');
     jest.spyOn(mockedEditorApi, 'selectFrames');
     jest.spyOn(mockedEditorApi, 'selectMultipleFrames');
+    jest.spyOn(mockedEditorApi, 'deselectFrames');
     jest.spyOn(mockedEditorApi, 'setFrameName');
     jest.spyOn(mockedEditorApi, 'setImageFrameFitMode');
     jest.spyOn(mockedEditorApi, 'setImageFrameFitModePosition');
@@ -332,6 +334,11 @@ describe('FrameController', () => {
         expect(mockedEditorApi.selectFrames).toHaveBeenCalledWith([id]);
     });
 
+    it('Should be possible to deselect all frames', async () => {
+        await mockedFrameController.deselectAll();
+        expect(mockedEditorApi.deselectFrames).toHaveBeenCalledTimes(1);
+    });
+
     it('Should be possible to set the image frame fit mode', async () => {
         await mockedFrameController.setImageFrameFitMode(id, FitMode.fit);
         expect(mockedEditorApi.setImageFrameFitMode).toHaveBeenCalledTimes(1);
@@ -343,7 +350,6 @@ describe('FrameController', () => {
         expect(mockedEditorApi.setImageFrameFitModePosition).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.setImageFrameFitModePosition).toHaveBeenCalledWith(id, FitModePosition.bottomCenter);
     });
-
 
     it('Should throw when trying to set the frame to constrain proportions - deprecated', async () => {
         await expect(mockedFrameController.setFrameConstrainProportions(id, true)).rejects.toThrow();


### PR DESCRIPTION
This PR exposes `deselectAll()` method in `FrameController`

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [EDT-1808](https://chilipublishintranet.atlassian.net/browse/EDT-1808)
