### PR TITLE
[Feature] [EDT-1756] Add available for user property to layouts

### DIFF
--- a/packages/sdk/src/controllers/LayoutController.ts
+++ b/packages/sdk/src/controllers/LayoutController.ts
@@ -370,4 +370,16 @@ export class LayoutController {
         const res = await this.#editorAPI;
         return res.setLayoutDisplayName(id, null).then((result) => getEditorResponseData<null>(result));
     };
+
+    /**
+     * This method will set the layout availability for end-users
+     *
+     * @param id The id of a specific layout
+     * @param isAvailable whether this layout is available for end-users
+     * @returns
+     */
+    setAvailableForUser = async (id: Id, isAvailable: boolean) => {
+        const res = await this.#editorAPI;
+        return res.setLayoutAvailableForUser(id, isAvailable).then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/packages/sdk/src/tests/controllers/LayoutController.test.ts
+++ b/packages/sdk/src/tests/controllers/LayoutController.test.ts
@@ -38,6 +38,7 @@ const mockedEditorApi: EditorAPI = {
     setLayoutDisplayName: async () => getEditorResponseData(castToEditorResponse(null)),
     getLayoutDisplayName: async () => getEditorResponseData(castToEditorResponse(null)),
     resetLayoutDisplayName: async () => getEditorResponseData(castToEditorResponse(null)),
+    setLayoutAvailableForUser: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -71,6 +72,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'setLayoutDisplayName');
     jest.spyOn(mockedEditorApi, 'getLayoutDisplayName');
     jest.spyOn(mockedEditorApi, 'resetLayoutDisplayName');
+    jest.spyOn(mockedEditorApi, 'setLayoutAvailableForUser');
 
     mockId = mockSelectPage.layoutId;
 });
@@ -312,5 +314,11 @@ describe('LayoutController', () => {
         await mockedLayoutController.getDisplayName('1');
         expect(mockedEditorApi.getLayoutDisplayName).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.getLayoutDisplayName).toHaveBeenCalledWith('1');
+    });
+
+    it('Should be possible to set layout availability', async () => {
+        await mockedLayoutController.setAvailableForUser('1', false);
+        expect(mockedEditorApi.setLayoutAvailableForUser).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.setLayoutAvailableForUser).toHaveBeenCalledWith('1', false);
     });
 });

--- a/packages/sdk/src/types/LayoutTypes.ts
+++ b/packages/sdk/src/types/LayoutTypes.ts
@@ -59,6 +59,7 @@ export type Layout = {
 export type LayoutListItemType = {
     id: string;
     name: string;
+    displayName?: string | null;
     type: LayoutType;
     availableForUser: boolean;
     parentId?: Id | null;

--- a/packages/sdk/src/types/LayoutTypes.ts
+++ b/packages/sdk/src/types/LayoutTypes.ts
@@ -52,6 +52,7 @@ export type Layout = {
     bleed: PropertyState<LayoutBleed>;
     fillColor: PropertyState<ColorUsage>;
     fillColorEnabled: PropertyState<boolean>;
+    availableForUser: boolean;
 };
 
 // used by onLayoutsChanged

--- a/packages/sdk/src/types/LayoutTypes.ts
+++ b/packages/sdk/src/types/LayoutTypes.ts
@@ -60,6 +60,7 @@ export type LayoutListItemType = {
     id: string;
     name: string;
     type: LayoutType;
+    availableForUser: boolean;
     parentId?: Id | null;
     childLayouts: Id[];
 };


### PR DESCRIPTION
This PR adds a new `availableForUser` property on the layout models and a new SDK method `setAvailableForUser`.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1756
https://chilipublishintranet.atlassian.net/browse/WRS-2280

----

Engine PR: https://github.com/chili-publish/studio-engine/pull/1648