### PR TITLE
[Feature] Add pause/resume methods for undo manager

### DIFF
--- a/packages/sdk/src/controllers/UndoManagerController.ts
+++ b/packages/sdk/src/controllers/UndoManagerController.ts
@@ -71,6 +71,24 @@ export class UndoManagerController {
             await this.#advanced.end();
         }
     };
+
+    /**
+     * This method pauses the undo manager
+     * @returns
+     */
+    pause = async () => {
+        const res = await this.#editorAPI;
+        return res.pause().then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method resumes the undo manager
+     * @returns
+     */
+    resume = async () => {
+        const res = await this.#editorAPI;
+        return res.resume().then((result) => getEditorResponseData<null>(result));
+    };
 }
 
 export class AdvancedUndoManagerController {

--- a/packages/sdk/src/tests/controllers/UndoManagerController.test.ts
+++ b/packages/sdk/src/tests/controllers/UndoManagerController.test.ts
@@ -17,6 +17,8 @@ describe('UndoManagerController', () => {
         beginIfNoneActive: async () => getEditorResponseData(castToEditorResponse(null)),
         setCustomUndoData: async () => getEditorResponseData(castToEditorResponse(null)),
         end: async () => getEditorResponseData(castToEditorResponse(null)),
+        pause: async () => getEditorResponseData(castToEditorResponse(null)),
+        resume: async () => getEditorResponseData(castToEditorResponse(null)),
     };
 
     beforeEach(() => {
@@ -28,6 +30,8 @@ describe('UndoManagerController', () => {
         jest.spyOn(mockEditorApi, 'setCustomUndoData');
         jest.spyOn(mockEditorApi, 'beginIfNoneActive');
         jest.spyOn(mockEditorApi, 'end');
+        jest.spyOn(mockEditorApi, 'pause');
+        jest.spyOn(mockEditorApi, 'resume');
     });
 
     afterEach(() => {
@@ -80,5 +84,15 @@ describe('UndoManagerController', () => {
         await mockedUndoManagerController.addCustomData(key, value);
         expect(mockEditorApi.setCustomUndoData).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.setCustomUndoData).toHaveBeenCalledWith(key, value);
+    });
+
+    it('it pauses the undo manager', async () => {
+        await mockedUndoManagerController.pause();
+        expect(mockEditorApi.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it('it resumes the undo manager', async () => {
+        await mockedUndoManagerController.pause();
+        expect(mockEditorApi.pause).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
This PR adds `pause` & `resume` methods to the undo manager.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-NUMBER](https://support.chili-publish.com/projects/WRS/issues/WRS-NUMBER)

https://chilipublishintranet.atlassian.net/browse/EDT-1803
