### PR TITLE
[Feature] [EDT-1817] [Snapshot] Define maximum time to wait for assets to be loaded

### DIFF
--- a/packages/sdk/src/types/PageTypes.ts
+++ b/packages/sdk/src/types/PageTypes.ts
@@ -23,4 +23,12 @@ export interface SnapshotSettings {
      * - The maximum allowed value is 1000 pixels.
      */
     largestAxisSize?: number | null;
+    /**
+     * The maximum time to wait in milliseconds for the assets to load before the snapshot is taken.
+     * 
+     * When the time is exceeded, the snapshot will be taken even if not all assets are loaded yet.
+     * 
+     * When not defined, the default value is 10000 ms.
+     */
+    maxWaitTimeMs?: number | null;
 }


### PR DESCRIPTION
This PR adds `maxWaitTimeMs` to `SnapshotSettings`.

## Related tickets

-   [EDT-1817](https://chilipublishintranet.atlassian.net/browse/EDT-1817)


[EDT-1817]: https://chilipublishintranet.atlassian.net/browse/EDT-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ