### PR TITLE
[FIX][NO-TICKET] Deprecate setVisible variable methods

### DIFF
--- a/packages/actions/types/Actions.d.ts
+++ b/packages/actions/types/Actions.d.ts
@@ -277,6 +277,7 @@ declare module 'grafx-studio-actions' {
             setRequired(value: boolean | VariableValue): void;
 
             /**
+             * @deprecated
              * Set the visible state of a variable
              * @param isVisible whether the variable is visible
              * @returns
@@ -703,6 +704,7 @@ declare module 'grafx-studio-actions' {
             setRequired(name: string | Variable, value: boolean | VariableValue): void;
 
             /**
+             * @deprecated
              * Set the visible state of a variable
              * @param name the variable name
              * @param isVisible whether the variable is visible


### PR DESCRIPTION
This PR deprecates extension methods to set visibility for variables

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)
