### PR TITLE
[Fix] Add frame visibility reset

### DIFF
--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -1018,4 +1018,14 @@ export class FrameController {
         const res = await this.#editorAPI;
         return res.resetFrameTransformation(id).then((result) => getEditorResponseData<null>(result));
     };
+
+    /**
+     * This method will reset the isVisible property of a specified frame.
+     * @param id the id of the frame that needs to get updated
+     * @returns
+     */
+    resetVisibility = async (id: Id) => {
+        const res = await this.#editorAPI;
+        return res.setFrameIsVisible(id, null).then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/packages/sdk/src/tests/controllers/FrameController.test.ts
+++ b/packages/sdk/src/tests/controllers/FrameController.test.ts
@@ -626,4 +626,10 @@ describe('Anchoring', () => {
         expect(mockedEditorApi.resetFrameTransformation).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.resetFrameTransformation).toHaveBeenLastCalledWith(id);
     });
+
+    it('should be possible to reset a frame visibility', async () => {
+        await mockedFrameController.resetVisibility(id);
+        expect(mockedEditorApi.setFrameIsVisible).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.setFrameIsVisible).toHaveBeenLastCalledWith(id, null);
+    });
 });


### PR DESCRIPTION
This PR adds a new `resetFrameVisibility` method

To be discussed: `resetFrameIsVisible`?

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1874
https://chilipublishintranet.atlassian.net/browse/WRS-1284
