### PR TITLE
[Fix] Add onFramesLayoutChanged

### DIFF
--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -75,9 +75,9 @@ export class SubscriberController {
      * Listener on the state of all frames, if this changes, this listener will get triggered with the updates
      * @param framesLayout Stringified array of FrameLayoutType objects
      */
-    onAllFramesLayoutChanged = (framesLayout: string) => {
+    onFramesLayoutChanged = (framesLayout: string) => {
         const frames = JSON.parse(framesLayout);
-        this.config.events.onAllFramesLayoutChanged.trigger(frames);
+        this.config.events.onFramesLayoutChanged.trigger(frames);
     };
 
     /**

--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -72,6 +72,15 @@ export class SubscriberController {
     };
 
     /**
+     * Listener on the state of all frames, if this changes, this listener will get triggered with the updates
+     * @param framesLayout Stringified array of FrameLayoutType objects
+     */
+    onAllFramesLayoutChanged = (framesLayout: string) => {
+        const frames = JSON.parse(framesLayout);
+        this.config.events.onAllFramesLayoutChanged.trigger(frames);
+    };
+
+    /**
      * Listener on the state of the currently selected frames, if this changes, this listener will get triggered with the updates
      * @param framesLayout Stringified array of FrameLayoutType objects
      */

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -53,6 +53,7 @@ interface ConfigParameterTypes {
     onDocumentLoaded: () => void;
     onSelectedFramesContentChanged: (state: string) => void;
     onSelectedFramesLayoutChanged: (state: string) => void;
+    onAllFramesLayoutChanged: (state: string) => void;
     onSelectedLayoutPropertiesChanged: (state: string) => void;
     onSelectedLayoutUnitChanged: (state: string) => void;
     onPageSelectionChanged: (id: Id) => void;
@@ -131,6 +132,7 @@ const Connect = (
                 viewportRequested: params.onViewportRequested,
                 selectedFramesContent: params.onSelectedFramesContentChanged,
                 selectedFramesLayout: params.onSelectedFramesLayoutChanged,
+                allFramesLayout: params.onAllFramesLayoutChanged,
                 selectedLayoutProperties: params.onSelectedLayoutPropertiesChanged,
                 openLayoutPropertiesPanel: params.onPageSelectionChanged,
                 selectedLayoutUnit: params.onSelectedLayoutUnitChanged,

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -53,7 +53,7 @@ interface ConfigParameterTypes {
     onDocumentLoaded: () => void;
     onSelectedFramesContentChanged: (state: string) => void;
     onSelectedFramesLayoutChanged: (state: string) => void;
-    onAllFramesLayoutChanged: (state: string) => void;
+    onFramesLayoutChanged: (state: string) => void;
     onSelectedLayoutPropertiesChanged: (state: string) => void;
     onSelectedLayoutUnitChanged: (state: string) => void;
     onPageSelectionChanged: (id: Id) => void;
@@ -132,7 +132,7 @@ const Connect = (
                 viewportRequested: params.onViewportRequested,
                 selectedFramesContent: params.onSelectedFramesContentChanged,
                 selectedFramesLayout: params.onSelectedFramesLayoutChanged,
-                allFramesLayout: params.onAllFramesLayoutChanged,
+                allFramesLayout: params.onFramesLayoutChanged,
                 selectedLayoutProperties: params.onSelectedLayoutPropertiesChanged,
                 openLayoutPropertiesPanel: params.onPageSelectionChanged,
                 selectedLayoutUnit: params.onSelectedLayoutUnitChanged,

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -156,7 +156,7 @@ export class SDK {
                 onDocumentLoaded: this.subscriber.onDocumentLoaded,
                 onSelectedFramesContentChanged: this.subscriber.onSelectedFramesContentChanged,
                 onSelectedFramesLayoutChanged: this.subscriber.onSelectedFramesLayoutChanged,
-                onAllFramesLayoutChanged: this.subscriber.onAllFramesLayoutChanged,
+                onFramesLayoutChanged: this.subscriber.onFramesLayoutChanged,
                 onSelectedLayoutPropertiesChanged: this.subscriber.onSelectedLayoutPropertiesChanged,
                 onSelectedLayoutUnitChanged: this.subscriber.onSelectedLayoutUnitChanged,
                 onPageSelectionChanged: this.subscriber.onPageSelectionChanged,

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -156,6 +156,7 @@ export class SDK {
                 onDocumentLoaded: this.subscriber.onDocumentLoaded,
                 onSelectedFramesContentChanged: this.subscriber.onSelectedFramesContentChanged,
                 onSelectedFramesLayoutChanged: this.subscriber.onSelectedFramesLayoutChanged,
+                onAllFramesLayoutChanged: this.subscriber.onAllFramesLayoutChanged,
                 onSelectedLayoutPropertiesChanged: this.subscriber.onSelectedLayoutPropertiesChanged,
                 onSelectedLayoutUnitChanged: this.subscriber.onSelectedLayoutUnitChanged,
                 onPageSelectionChanged: this.subscriber.onPageSelectionChanged,

--- a/packages/sdk/src/tests/__mocks__/Config.ts
+++ b/packages/sdk/src/tests/__mocks__/Config.ts
@@ -12,7 +12,7 @@ const mockConfig: RuntimeConfigType = ConfigHelper.createRuntimeConfig({
     onDocumentLoaded: defaultMockReturn,
     onSelectedFrameLayoutChanged: defaultMockReturn,
     onSelectedFramesLayoutChanged: defaultMockReturn,
-    onAllFramesLayoutChanged: defaultMockReturn,
+    onFramesLayoutChanged: defaultMockReturn,
     onSelectedFrameContentChanged: defaultMockReturn,
     onSelectedFramesContentChanged: defaultMockReturn,
     editorLink: 'https://chili-editor-dev.azurewebsites.net/',

--- a/packages/sdk/src/tests/__mocks__/Config.ts
+++ b/packages/sdk/src/tests/__mocks__/Config.ts
@@ -12,6 +12,7 @@ const mockConfig: RuntimeConfigType = ConfigHelper.createRuntimeConfig({
     onDocumentLoaded: defaultMockReturn,
     onSelectedFrameLayoutChanged: defaultMockReturn,
     onSelectedFramesLayoutChanged: defaultMockReturn,
+    onAllFramesLayoutChanged: defaultMockReturn,
     onSelectedFrameContentChanged: defaultMockReturn,
     onSelectedFramesContentChanged: defaultMockReturn,
     editorLink: 'https://chili-editor-dev.azurewebsites.net/',

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -45,7 +45,7 @@ const mockEditorApi: EditorAPI = {
     onAnimationChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFrameLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFramesLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
-    onAllFramesLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
+    onFramesLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFrameContentChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFramesContentChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onPageSelectionChanged: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -91,7 +91,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'onAnimationChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFrameLayoutChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFramesLayoutChanged');
-    jest.spyOn(mockEditorApi, 'onAllFramesLayoutChanged');
+    jest.spyOn(mockEditorApi, 'onFramesLayoutChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFrameContentChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFramesContentChanged');
     jest.spyOn(mockEditorApi, 'onPageSelectionChanged');
@@ -168,17 +168,17 @@ describe('SubscriberController', () => {
         expect(mockEditorApi.onSelectedFrameLayoutChanged).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.onSelectedFrameLayoutChanged).toHaveBeenCalledWith(undefined);
     });
-    it('Should be possible to subscribe to onAllFramesLayoutChanged when a single frame is passed', async () => {
-        await mockedSubscriberController.onAllFramesLayoutChanged('[2]');
+    it('Should be possible to subscribe to onFramesLayoutChanged when a single frame is passed', async () => {
+        await mockedSubscriberController.onFramesLayoutChanged('[2]');
 
-        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledWith([2]);
+        expect(mockEditorApi.onFramesLayoutChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onFramesLayoutChanged).toHaveBeenCalledWith([2]);
     });
-    it('Should be possible to subscribe to onAllFramesLayoutChanged when multiple frames are passed', async () => {
-        await mockedSubscriberController.onAllFramesLayoutChanged('[1,2]');
+    it('Should be possible to subscribe to onFramesLayoutChanged when multiple frames are passed', async () => {
+        await mockedSubscriberController.onFramesLayoutChanged('[1,2]');
 
-        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledWith([1, 2]);
+        expect(mockEditorApi.onFramesLayoutChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onFramesLayoutChanged).toHaveBeenCalledWith([1, 2]);
     });
     it('Should be possible to subscribe to onSelectedFramesContentChanged when a single frame is passed', async () => {
         await mockedSubscriberController.onSelectedFramesContentChanged('[2]');

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -45,6 +45,7 @@ const mockEditorApi: EditorAPI = {
     onAnimationChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFrameLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFramesLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
+    onAllFramesLayoutChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFrameContentChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onSelectedFramesContentChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onPageSelectionChanged: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -90,6 +91,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'onAnimationChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFrameLayoutChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFramesLayoutChanged');
+    jest.spyOn(mockEditorApi, 'onAllFramesLayoutChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFrameContentChanged');
     jest.spyOn(mockEditorApi, 'onSelectedFramesContentChanged');
     jest.spyOn(mockEditorApi, 'onPageSelectionChanged');
@@ -165,6 +167,18 @@ describe('SubscriberController', () => {
 
         expect(mockEditorApi.onSelectedFrameLayoutChanged).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.onSelectedFrameLayoutChanged).toHaveBeenCalledWith(undefined);
+    });
+    it('Should be possible to subscribe to onAllFramesLayoutChanged when a single frame is passed', async () => {
+        await mockedSubscriberController.onAllFramesLayoutChanged('[2]');
+
+        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledWith([2]);
+    });
+    it('Should be possible to subscribe to onAllFramesLayoutChanged when multiple frames are passed', async () => {
+        await mockedSubscriberController.onAllFramesLayoutChanged('[1,2]');
+
+        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onAllFramesLayoutChanged).toHaveBeenCalledWith([1, 2]);
     });
     it('Should be possible to subscribe to onSelectedFramesContentChanged when a single frame is passed', async () => {
         await mockedSubscriberController.onSelectedFramesContentChanged('[2]');

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -81,7 +81,7 @@ export type ManagedCallbacksConfigType = {
         onStateChanged: EngineEvent<() => MaybePromise<void>>;
         onDocumentLoaded: EngineEvent<() => MaybePromise<void>>;
         onSelectedFramesLayoutChanged: EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>;
-        onAllFramesLayoutChanged: EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>;
+        onFramesLayoutChanged: EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>;
         onSelectedFramesContentChanged: EngineEvent<(state: Frame[]) => MaybePromise<void>>;
         onPageSelectionChanged: EngineEvent<(id: Id) => MaybePromise<void>>;
         onSelectedLayoutPropertiesChanged: EngineEvent<(state: LayoutPropertiesType) => MaybePromise<void>>;
@@ -158,9 +158,9 @@ export type InitialCallbacksConfigType = {
     onSelectedFramesLayoutChanged?: (states: FrameLayoutType[]) => void;
 
     /**
-     * @deprecated use `events.onAllFramesLayoutChanged` instead
+     * @deprecated use `events.onFramesLayoutChanged` instead
      */
-    onAllFramesLayoutChanged?: (states: FrameLayoutType[]) => void;
+    onFramesLayoutChanged?: (states: FrameLayoutType[]) => void;
 
     /**
      * @deprecated use `onSelectedFramesContentChanged` instead

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -81,6 +81,7 @@ export type ManagedCallbacksConfigType = {
         onStateChanged: EngineEvent<() => MaybePromise<void>>;
         onDocumentLoaded: EngineEvent<() => MaybePromise<void>>;
         onSelectedFramesLayoutChanged: EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>;
+        onAllFramesLayoutChanged: EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>;
         onSelectedFramesContentChanged: EngineEvent<(state: Frame[]) => MaybePromise<void>>;
         onPageSelectionChanged: EngineEvent<(id: Id) => MaybePromise<void>>;
         onSelectedLayoutPropertiesChanged: EngineEvent<(state: LayoutPropertiesType) => MaybePromise<void>>;
@@ -155,6 +156,11 @@ export type InitialCallbacksConfigType = {
      * @deprecated use `events.onSelectedFramesLayoutChanged` instead
      */
     onSelectedFramesLayoutChanged?: (states: FrameLayoutType[]) => void;
+
+    /**
+     * @deprecated use `events.onAllFramesLayoutChanged` instead
+     */
+    onAllFramesLayoutChanged?: (states: FrameLayoutType[]) => void;
 
     /**
      * @deprecated use `onSelectedFramesContentChanged` instead

--- a/packages/sdk/src/utils/ConfigHelper.ts
+++ b/packages/sdk/src/utils/ConfigHelper.ts
@@ -87,8 +87,8 @@ export class ConfigHelper {
                 () => clone.onSelectedFramesLayoutChanged,
                 clone.logging?.logger,
             ),
-            onAllFramesLayoutChanged: new EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>(
-                () => clone.onAllFramesLayoutChanged,
+            onFramesLayoutChanged: new EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>(
+                () => clone.onFramesLayoutChanged,
                 clone.logging?.logger,
             ),
             onSelectedFramesContentChanged: new EngineEvent<(state: Frame[]) => MaybePromise<void>>(

--- a/packages/sdk/src/utils/ConfigHelper.ts
+++ b/packages/sdk/src/utils/ConfigHelper.ts
@@ -87,6 +87,10 @@ export class ConfigHelper {
                 () => clone.onSelectedFramesLayoutChanged,
                 clone.logging?.logger,
             ),
+            onAllFramesLayoutChanged: new EngineEvent<(states: FrameLayoutType[]) => MaybePromise<void>>(
+                () => clone.onAllFramesLayoutChanged,
+                clone.logging?.logger,
+            ),
             onSelectedFramesContentChanged: new EngineEvent<(state: Frame[]) => MaybePromise<void>>(
                 () => clone.onSelectedFramesContentChanged,
                 clone.logging?.logger,


### PR DESCRIPTION
This PR adds a new `onAllFramesLayoutChanged` stream that is a deviation from already existing `onSelectedFramesLayoutChanged`.

Alternative name: `onFramesLayoutChanged`

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1875
https://chilipublishintranet.atlassian.net/browse/WRS-1284