### PR TITLE
[Feature] Provide valid configurations and targets for anchoring to sdk

### DIFF
--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -1041,7 +1041,7 @@ export class FrameController {
      * @param id the id of the frame to get the frame configuration for
      * @returns the frame's configuration
      */
-    getFrameConfiguration = async (id: Id) => {
+    getConfiguration = async (id: Id) => {
         const res = await this.#editorAPI;
         return res.getFrameConfiguration(id).then((result) => getEditorResponseData<FrameConfiguration>(result));
     };

--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -18,6 +18,7 @@ import {
     ImageSourceTypeEnum,
     UpdateZIndexMethod,
     VerticalAlign,
+    FrameConfiguration,
 } from '../types/FrameTypes';
 import { ColorUsage } from '../types/ColorStyleTypes';
 import { ShapeType } from '../types/ShapeTypes';
@@ -1027,5 +1028,21 @@ export class FrameController {
     resetVisibility = async (id: Id) => {
         const res = await this.#editorAPI;
         return res.setFrameIsVisible(id, null).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will get the frame configuration for a specified frame.
+     *
+     * A frame configuration is a set of rules that define what is allowed to
+     * do with a given behavior of a frame.
+     *
+     * e.g. list of allowed frame targets for a specific anchor
+     *
+     * @param id the id of the frame to get the frame configuration for
+     * @returns the frame's configuration
+     */
+    getFrameConfiguration = async (id: Id) => {
+        const res = await this.#editorAPI;
+        return res.getFrameConfiguration(id).then((result) => getEditorResponseData<FrameConfiguration>(result));
     };
 }

--- a/packages/sdk/src/tests/controllers/FrameController.test.ts
+++ b/packages/sdk/src/tests/controllers/FrameController.test.ts
@@ -636,7 +636,7 @@ describe('Anchoring', () => {
     });
 
     it('should be possible to get frame configuration', async () => {
-        await mockedFrameController.getFrameConfiguration(id);
+        await mockedFrameController.getConfiguration(id);
         expect(mockedEditorApi.getFrameConfiguration).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.getFrameConfiguration).toHaveBeenCalledWith(id);
     });

--- a/packages/sdk/src/tests/controllers/FrameController.test.ts
+++ b/packages/sdk/src/tests/controllers/FrameController.test.ts
@@ -77,6 +77,7 @@ const mockedEditorApi: EditorAPI = {
     resetCropMode: async () => getEditorResponseData(castToEditorResponse(null)),
     updateAutoGrowSettings: async () => getEditorResponseData(castToEditorResponse(null)),
     setAnchorProperties: async () => getEditorResponseData(castToEditorResponse(null)),
+    getFrameConfiguration: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -132,6 +133,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'resetCropMode');
     jest.spyOn(mockedEditorApi, 'updateAutoGrowSettings');
     jest.spyOn(mockedEditorApi, 'setAnchorProperties');
+    jest.spyOn(mockedEditorApi, 'getFrameConfiguration');
 
     id = mockSelectFrame.id;
 });
@@ -631,5 +633,11 @@ describe('Anchoring', () => {
         await mockedFrameController.resetVisibility(id);
         expect(mockedEditorApi.setFrameIsVisible).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.setFrameIsVisible).toHaveBeenLastCalledWith(id, null);
+    });
+
+    it('should be possible to get frame configuration', async () => {
+        await mockedFrameController.getFrameConfiguration(id);
+        expect(mockedEditorApi.getFrameConfiguration).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.getFrameConfiguration).toHaveBeenCalledWith(id);
     });
 });

--- a/packages/sdk/src/types/FrameTypes.ts
+++ b/packages/sdk/src/types/FrameTypes.ts
@@ -354,3 +354,13 @@ export type FrameAnchorProperties = {
     target: AnchorTarget;
     endTarget?: AnchorTarget | null;
 };
+
+export type AnchorConfiguration = {
+    allowedTypes: Set<FrameAnchorType>;
+    allowedFrameIds: Set<Id>;
+};
+
+export type FrameConfiguration = {
+    horizontal: AnchorConfiguration;
+    vertical: AnchorConfiguration;
+};


### PR DESCRIPTION
This PR adds a new `getConfiguration` method to the frame controller to get configurations given certain behaviors of a frame.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1876
