### PR TITLE
[Fix] Allow event skipping w/ custom undo

### DIFF
--- a/packages/sdk/src/controllers/ExperimentController.ts
+++ b/packages/sdk/src/controllers/ExperimentController.ts
@@ -101,4 +101,20 @@ export class ExperimentController {
         const res = await this.#editorAPI;
         return res.selectTextById(frameId, startIndex, length).then((result) => getEditorResponseData<null>(result));
     };
+
+    /**
+     * This method adds custom data that will be saved and restored when undoing and redoing.
+     * Duplicate values are overwritten. The data is exposed via the onCustomUndoDataChanged event.
+     *
+     * @param key The key of the custom data
+     * @param value The value of the custom data
+     * @param skipEvent Whether to skip the event that is triggered when the custom data is changed, defaults to false
+     * @returns
+     */
+    addCustomUndoData = async (key: string, value: string, skipEvent?: boolean) => {
+        const res = await this.#editorAPI;
+        return res
+            .setCustomUndoData(key, value, skipEvent ?? false)
+            .then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/packages/sdk/src/controllers/UndoManagerController.ts
+++ b/packages/sdk/src/controllers/UndoManagerController.ts
@@ -51,7 +51,7 @@ export class UndoManagerController {
      */
     addCustomData = async (key: string, value: string) => {
         const res = await this.#editorAPI;
-        return res.setCustomUndoData(key, value).then((result) => getEditorResponseData<null>(result));
+        return res.setCustomUndoData(key, value, false).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/packages/sdk/src/tests/controllers/ExperimentController.test.ts
+++ b/packages/sdk/src/tests/controllers/ExperimentController.test.ts
@@ -16,6 +16,7 @@ const mockedEditorApi: EditorAPI = {
     getTextByFrameId: async () => getEditorResponseData(castToEditorResponse(null)),
     setTextByFrameId: async () => getEditorResponseData(castToEditorResponse(null)),
     selectTextById: async () => getEditorResponseData(castToEditorResponse(null)),
+    setCustomUndoData: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -28,6 +29,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'getTextByFrameId');
     jest.spyOn(mockedEditorApi, 'setTextByFrameId');
     jest.spyOn(mockedEditorApi, 'selectTextById');
+    jest.spyOn(mockedEditorApi, 'setCustomUndoData');
 
     frameId = mockSelectFrame.id;
 });
@@ -85,5 +87,24 @@ describe('ExperimentController', () => {
         await mockedExperimentController.selectText(frameId, startIndex, length);
         expect(mockedEditorApi.selectTextById).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.selectTextById).toHaveBeenCalledWith(frameId, startIndex, length);
+    });
+
+    it('Should call setCustomUndoData of EditorAPI successfully', async () => {
+        const key = 'testKey';
+        const value = 'testValue';
+        const skipEvent = true;
+
+        await mockedExperimentController.addCustomUndoData(key, value, skipEvent);
+        expect(mockedEditorApi.setCustomUndoData).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.setCustomUndoData).toHaveBeenCalledWith(key, value, skipEvent);
+    });
+
+    it('Should call setCustomUndoData of EditorAPI with default skipEvent value', async () => {
+        const key = 'testKey';
+        const value = 'testValue';
+
+        await mockedExperimentController.addCustomUndoData(key, value);
+        expect(mockedEditorApi.setCustomUndoData).toHaveBeenCalledTimes(2);
+        expect(mockedEditorApi.setCustomUndoData).toHaveBeenCalledWith(key, value, false);
     });
 });

--- a/packages/sdk/src/tests/controllers/UndoManagerController.test.ts
+++ b/packages/sdk/src/tests/controllers/UndoManagerController.test.ts
@@ -83,7 +83,7 @@ describe('UndoManagerController', () => {
 
         await mockedUndoManagerController.addCustomData(key, value);
         expect(mockEditorApi.setCustomUndoData).toHaveBeenCalledTimes(1);
-        expect(mockEditorApi.setCustomUndoData).toHaveBeenCalledWith(key, value);
+        expect(mockEditorApi.setCustomUndoData).toHaveBeenCalledWith(key, value, false);
     });
 
     it('it pauses the undo manager', async () => {


### PR DESCRIPTION
This PR allows setting a custom undo operation without triggering an event.
This method is in experimental as we want to find a more long-term approach to that scenario.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1902
https://chilipublishintranet.atlassian.net/browse/MAIN-1156
