### PR TITLE
[Feature] Add allowUpload & allowQuery to image variable

### DIFF
--- a/packages/sdk/src/controllers/VariableController.ts
+++ b/packages/sdk/src/controllers/VariableController.ts
@@ -658,6 +658,28 @@ export class VariableController {
         return res.getVariablePrivateData(id).then((result) => getEditorResponseData<PrivateData>(result));
     };
 
+    /**
+     * This method sets the allowQuery flag for an image variable
+     * @param id the id of the variable
+     * @param allowQuery the allowQuery flag
+     * @returns
+     */
+    setAllowImageQuery = async (id: string, allowQuery: boolean) => {
+        const res = await this.#editorAPI;
+        return res.setImageVariableAllowQuery(id, allowQuery).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method sets the allowUpload flag for an image variable
+     * @param id the id of the variable
+     * @param allowUpload the allowUpload flag
+     * @returns
+     */
+    setAllowImageUpload = async (id: string, allowUpload: boolean) => {
+        const res = await this.#editorAPI;
+        return res.setImageVariableAllowUpload(id, allowUpload).then((result) => getEditorResponseData<null>(result));
+    };
+
     private makeVariablesBackwardsCompatible(variables: Variable[]) {
         return variables.map((variable) => {
             return this.makeVariableBackwardsCompatible(variable);

--- a/packages/sdk/src/next/controllers/VariableController.ts
+++ b/packages/sdk/src/next/controllers/VariableController.ts
@@ -13,12 +13,14 @@ export class VariableController {
      * @ignore
      */
     #editorAPI: EditorAPI;
+    image: ImageVariableController;
 
     /**
      * @ignore
      */
     constructor(editorAPI: EditorAPI) {
         this.#editorAPI = editorAPI;
+        this.image = new ImageVariableController(editorAPI);
     }
 
     /**
@@ -86,5 +88,23 @@ export class VariableController {
         return res
             .setImageVariableConnector(id, JSON.stringify(registration))
             .then((result) => getEditorResponseData<Id>(result));
+    };
+}
+
+export class ImageVariableController {
+    #editorAPI: EditorAPI;
+
+    constructor(editorAPI: EditorAPI) {
+        this.#editorAPI = editorAPI;
+    }
+
+    setAllowQuery = async (id: string, allowQuery: boolean) => {
+        const res = await this.#editorAPI;
+        return res.setImageVariableAllowQuery(id, allowQuery).then((result) => getEditorResponseData<null>(result));
+    };
+
+    setAllowUpload = async (id: string, allowUpload: boolean) => {
+        const res = await this.#editorAPI;
+        return res.setImageVariableAllowUpload(id, allowUpload).then((result) => getEditorResponseData<null>(result));
     };
 }

--- a/packages/sdk/src/next/tests/controllers/VariableController.test.ts
+++ b/packages/sdk/src/next/tests/controllers/VariableController.test.ts
@@ -1,4 +1,4 @@
-import { VariableController } from '../../controllers/VariableController';
+import { ImageVariableController, VariableController } from '../../controllers/VariableController';
 import { ListVariableItem, Variable, VariableType, VariableVisibilityType } from '../../../types/VariableTypes';
 import type { ListVariable } from '../../../next/types/VariableTypes';
 import { EditorAPI } from '../../../types/CommonTypes';
@@ -145,5 +145,38 @@ describe('Next.VariableController', () => {
             JSON.stringify(grafxRegistration),
         );
         expect(response?.parsedData).toBe('newConnectorId');
+    });
+});
+
+describe('Next.VariableController.ImageVariableController', () => {
+    let mockedImageVariableController: ImageVariableController;
+
+    const variableId = 'variableId';
+
+    const mockEditorApi: EditorAPI = {
+        setImageVariableAllowQuery: async () => getEditorResponseData(castToEditorResponse(null)),
+        setImageVariableAllowUpload: async () => getEditorResponseData(castToEditorResponse(null)),
+    };
+
+    beforeEach(() => {
+        mockedImageVariableController = new ImageVariableController(mockEditorApi);
+        jest.spyOn(mockEditorApi, 'setImageVariableAllowQuery');
+        jest.spyOn(mockEditorApi, 'setImageVariableAllowUpload');
+    });
+
+    it('set allow query', async () => {
+        const response = await mockedImageVariableController.setAllowQuery(variableId, true);
+
+        expect(mockEditorApi.setImageVariableAllowQuery).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.setImageVariableAllowQuery).toHaveBeenCalledWith(variableId, true);
+        expect(response?.parsedData).toBe(null);
+    });
+
+    it('set allow upload', async () => {
+        const response = await mockedImageVariableController.setAllowUpload(variableId, true);
+
+        expect(mockEditorApi.setImageVariableAllowUpload).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.setImageVariableAllowUpload).toHaveBeenCalledWith(variableId, true);
+        expect(response?.parsedData).toBe(null);
     });
 });

--- a/packages/sdk/src/tests/controllers/VariableController.test.ts
+++ b/packages/sdk/src/tests/controllers/VariableController.test.ts
@@ -43,6 +43,8 @@ describe('VariableController', () => {
             },
         },
         privateData: {},
+        allowQuery: true,
+        allowUpload: true,
     };
 
     const listVar: Variable & { items: ListVariableItem[]; selected?: ListVariableItem } = {
@@ -92,6 +94,8 @@ describe('VariableController', () => {
         updateVariablePrefixSuffixProperties: async () => getEditorResponseData(castToEditorResponse(null)),
         setVariablePrivateData: async () => getEditorResponseData(castToEditorResponse(null)),
         getVariablePrivateData: async () => getEditorResponseData(castToEditorResponse(privateData)),
+        setImageVariableAllowQuery: async () => getEditorResponseData(castToEditorResponse(null)),
+        setImageVariableAllowUpload: async () => getEditorResponseData(castToEditorResponse(null)),
     };
 
     beforeEach(() => {
@@ -125,6 +129,8 @@ describe('VariableController', () => {
         jest.spyOn(mockEditorApi, 'updateVariablePrefixSuffixProperties');
         jest.spyOn(mockEditorApi, 'setVariablePrivateData');
         jest.spyOn(mockEditorApi, 'getVariablePrivateData');
+        jest.spyOn(mockEditorApi, 'setImageVariableAllowQuery');
+        jest.spyOn(mockEditorApi, 'setImageVariableAllowUpload');
     });
 
     it('get variable by id', async () => {
@@ -540,5 +546,17 @@ describe('VariableController', () => {
         expect(mockEditorApi.getVariablePrivateData).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.getVariablePrivateData).toHaveBeenCalledWith('1');
         expect(response?.parsedData).toStrictEqual(privateData);
+    });
+
+    it('sets the allowQuery flag for an image variable', async () => {
+        await mockedVariableController.setAllowImageQuery('1', true);
+        expect(mockEditorApi.setImageVariableAllowQuery).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.setImageVariableAllowQuery).toHaveBeenCalledWith('1', true);
+    });
+
+    it('sets the allowUpload flag for an image variable', async () => {
+        await mockedVariableController.setAllowImageUpload('1', true);
+        expect(mockEditorApi.setImageVariableAllowUpload).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.setImageVariableAllowUpload).toHaveBeenCalledWith('1', true);
     });
 });

--- a/packages/sdk/src/types/VariableTypes.ts
+++ b/packages/sdk/src/types/VariableTypes.ts
@@ -53,6 +53,8 @@ export interface Variable {
 
 export interface ImageVariable extends Variable {
     value?: ConnectorImageVariableSource;
+    allowQuery: boolean;
+    allowUpload: boolean;
 }
 
 export interface ListVariableItem {


### PR DESCRIPTION
This PR adds `setAllowImageQuery` & `setAllowImageUpload` to the variable controller.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/WRS-2439
https://chilipublishintranet.atlassian.net/browse/EDT-1951
