### PR TITLE
[Feature][EDT-1955]  resetAllAssetCropOverrides

### DIFF
--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -1056,5 +1056,15 @@ export class FrameController {
     resetAssetCropOverride = async (id: Id) => {
         const res = await this.#editorAPI;
         return res.resetAssetCropOverride(id).then((result) => getEditorResponseData<null>(result));
-    }
+    };
+
+    /**
+     * This method will reset all crop overrides for the specified frame
+     * @param id the id of the frame
+     * @returns
+     */
+    resetAllAssetCropOverrides = async (id: Id) => {
+        const res = await this.#editorAPI;
+        return res.resetAllAssetCropOverrides(id).then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/packages/sdk/src/tests/controllers/FrameController.test.ts
+++ b/packages/sdk/src/tests/controllers/FrameController.test.ts
@@ -79,6 +79,8 @@ const mockedEditorApi: EditorAPI = {
     updateAutoGrowSettings: async () => getEditorResponseData(castToEditorResponse(null)),
     setAnchorProperties: async () => getEditorResponseData(castToEditorResponse(null)),
     getFrameConfiguration: async () => getEditorResponseData(castToEditorResponse(null)),
+    resetAssetCropOverride: async () => getEditorResponseData(castToEditorResponse(null)),
+    resetAllAssetCropOverrides: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -135,6 +137,8 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'updateAutoGrowSettings');
     jest.spyOn(mockedEditorApi, 'setAnchorProperties');
     jest.spyOn(mockedEditorApi, 'getFrameConfiguration');
+    jest.spyOn(mockedEditorApi, 'resetAssetCropOverride');
+    jest.spyOn(mockedEditorApi, 'resetAllAssetCropOverrides');
 
     id = mockSelectFrame.id;
 });
@@ -481,9 +485,16 @@ describe('FrameController', () => {
         expect(mockedEditorApi.applySubjectMode).toHaveBeenCalledTimes(1);
     });
 
-    it('Should be possible to cancel the current subject area', async () => {
-        await mockedFrameController.exitSubjectMode();
-        expect(mockedEditorApi.cancelSubjectMode).toHaveBeenCalledTimes(1);
+    it('Should be possible to reset asset crop override', async () => {
+        await mockedFrameController.resetAssetCropOverride(id);
+        expect(mockedEditorApi.resetAssetCropOverride).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.resetAssetCropOverride).toHaveBeenCalledWith(id);
+    });
+
+    it('Should be possible to reset all asset crop overrides', async () => {
+        await mockedFrameController.resetAllAssetCropOverrides(id);
+        expect(mockedEditorApi.resetAllAssetCropOverrides).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.resetAllAssetCropOverrides).toHaveBeenCalledWith(id);
     });
 });
 


### PR DESCRIPTION
This PR adds resetAllAssetCropOverrides method

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [EDT-1955](https://chilipublishintranet.atlassian.net/browse/EDT-1955)


[EDT-1955]: https://chilipublishintranet.atlassian.net/browse/EDT-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ