### PR TITLE
[Fix] Get back dev release for merge to main

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -3,12 +3,11 @@ on:
   push:
     branches:
       - main
+env:
+  NODE_VERSION: 20
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,10 +20,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-0
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Use Node ${{ matrix.node-version }}
+      - name: Use Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://npm.pkg.github.com"
           scope: "@chili-publish"
       - name: install dependencies
@@ -33,5 +32,48 @@ jobs:
         run: yarn ci-lint
       - name: run tests
         run: yarn cover
+      - name: bump version
+        uses: phips28/gh-action-bump-version@v11.0.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_SECRET }}
+        with:
+          version-type: "prerelease"
+          skip-commit: "true"
+          skip-tag: "true"
+          preid: alfa
+      - name: execute local js script
+        run: node ./.github/scripts/replicate-version.js
       - name: build code
         run: yarn build
+      - name: publish sdk build
+        run: node cicd.js sdk,connectors yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_SECRET }}
+      # execute commit script
+      - name: execute commit script
+        run: node ./.github/scripts/commit.js
+      - name: get new npm version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+      - name: copy file branch
+        run: |
+          path=packages/sdk/upload/latest
+          versionpath=packages/sdk/upload/${{ steps.package-version.outputs.current-version}}
+          mkdir -p ${path%"/merge"}
+          cp -R packages/sdk/_bundles/* ${path%"/merge"}
+          mkdir -p ${versionpath%"/merge"}
+          cp -R packages/sdk/_bundles/* ${versionpath%"/merge"}
+      - name: Copy to Azure Blob Storage (SDK)
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload-batch -d sdk -s packages/sdk/upload/ --connection-string "${{ secrets.AZURE_CDN_STUDIO_DEV_CONNECTION_STRING }}" --overwrite true
+      - name: prepare for actions upload
+        run: |
+          node cicd.js actions node scripts/prepare-release.mjs
+      - name: Copy to Azure Blob Storage (Actions)
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload-batch -d sdk -s packages/actions/cdn/ --connection-string "${{ secrets.AZURE_CDN_STUDIO_DEV_CONNECTION_STRING }}" --overwrite true

--- a/.github/workflows/publish-release-npm.yml
+++ b/.github/workflows/publish-release-npm.yml
@@ -2,12 +2,11 @@ name: Publish Release
 on:
   release:
     types: [released]
+env:
+  NODE_VERSION: 20
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,10 +19,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-0
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Use Node ${{ matrix.node-version }}
+      - name: Use Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
       - name: install dependencies
         run: yarn install
@@ -56,10 +55,10 @@ jobs:
           node cicd.js sdk,connectors yarn publish --tag $stripped_tag --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - name: Use Node ${{ matrix.node-version }} for dev release
+      - name: Use Node ${{ env.NODE_VERSION }} for dev release
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://npm.pkg.github.com"
           scope: "@chili-publish"
       - name: publish sdk build
@@ -96,40 +95,15 @@ jobs:
           inlineScript: |
             az storage blob upload-batch -d sdk -s packages/actions/cdn/ --connection-string "${{ secrets.AZURE_CDN_STUDIO_PRD_CONNECTION_STRING }}" --overwrite true
 
-  bump:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
-    needs: build
-    steps:
-      - uses: FranzDiebold/github-env-vars-action@v2
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PACKAGE_SECRET }}
-      - name: Bump version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git fetch origin
-          git checkout -B main origin/main
-          npm version prepatch --git-tag-version=false
-      - name: execute local js script
-        run: node ./.github/scripts/replicate-version.js
-      - name: execute commit script
-        run: node ./.github/scripts/commit.js
-
   update-version-management:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18
+      - uses: actions/checkout@v4
+      - name: Use Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
       - name: Download and update versions file
         run: |
           # Create temporary directory
@@ -177,3 +151,27 @@ jobs:
         with:
           inlineScript: |
             az storage blob upload --file temp/supported-versions.json --container-name shared --name version-management/supported-versions.json --connection-string "${{ secrets.AZURE_CDN_STUDIO_PRD_CONNECTION_STRING }}" --overwrite true
+  bump-version:
+    runs-on: ubuntu-latest
+    needs: [update-version-management]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PACKAGE_SECRET }}
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Bump version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git fetch origin
+          git checkout -B main origin/main
+          npm version prepatch --git-tag-version=false
+      - name: execute local js script
+        run: node ./.github/scripts/replicate-version.js
+      - name: execute commit script
+        run: node ./.github/scripts/commit.js

--- a/.github/workflows/publish-release-uat.yml
+++ b/.github/workflows/publish-release-uat.yml
@@ -2,12 +2,11 @@ name: Publish Release UAT
 on:
   release:
     types: [prereleased]
+env:
+  NODE_VERSION: 20
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,23 +19,29 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-0
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: Use Node ${{ matrix.node-version }}
+      - name: Use Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://npm.pkg.github.com"
           scope: "@chili-publish"
       - name: install dependencies
         run: yarn install
-      - name: bump version
-        uses: phips28/gh-action-bump-version@v11.0.7
+      - name: run linting
+        run: yarn ci-lint
+      - name: run tests
+        run: yarn cover
+      - name: bump version locally
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_SECRET }}
-        with:
-          version-type: "prerelease"
-          skip-commit: "true"
-          skip-tag: "true"
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git fetch origin
+          git checkout -B main origin/main
+          npm version prerelease --git-tag-version=false --preid=rc
+      - name: run readmeUpdater
+        run: yarn make-badges
       - name: execute local js script
         run: node ./.github/scripts/replicate-version.js
       - name: build code
@@ -78,12 +83,13 @@ jobs:
 
   update-version-management:
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18
+      - name: Use Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
       - name: Download and update versions file
         run: |
           # Create temporary directory


### PR DESCRIPTION
This PR
- Bring back the semver dev release for merge to main (with `alfa` preid)
- Keep using `rc` for UAT releases
- Update node version to 20 in all release workflows

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-NUMBER](https://support.chili-publish.com/projects/WRS/issues/WRS-NUMBER)

## Screenshots
