### PR TITLE
[Fix][WRS-2521] Fix return type and actual param value for certain page controller methods and events

### DIFF
--- a/packages/sdk/src/controllers/PageController.ts
+++ b/packages/sdk/src/controllers/PageController.ts
@@ -29,22 +29,22 @@ export class PageController {
     /**
      * @experimental
      * This method adds a new page.
-     * @returns
+     * @returns the id of the new page
      */
     add = async () => {
         const res = await this.#editorAPI;
-        return res.addPage().then((result) => getEditorResponseData<null>(result));
+        return res.addPage().then((result) => getEditorResponseData<Id>(result));
     };
 
     /**
      * @experimental
      * This method removes a certain page.
      * @param pageId the id of the page
-     * @returns
+     * @returns the id of the current active page
      */
     remove = async (pageId: Id) => {
         const res = await this.#editorAPI;
-        return res.removePage(pageId).then((result) => getEditorResponseData<null>(result));
+        return res.removePage(pageId).then((result) => getEditorResponseData<Id>(result));
     };
 
     /**

--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -326,10 +326,10 @@ export class SubscriberController {
     /**
      * @experimental
      * Listener on pages snapshots, this will fire when a page snapshot is invalidated and should be updated.
-     * @param page id of the page
+     * @param pageId id of the page
      */
-    onPageSnapshotInvalidated = (page: Id) => {
-        this.config.events.onPageSnapshotInvalidated.trigger(JSON.parse(page));
+    onPageSnapshotInvalidated = (pageId: Id) => {
+        this.config.events.onPageSnapshotInvalidated.trigger(pageId);
     };
     /**
      * Listener on page size, this listener will get triggered when the page size is changed, while the document is a `project`.

--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -149,6 +149,7 @@ export class SubscriberController {
     };
 
     /**
+     * @deprecated use `onSelectedPageIdChanged` instead
      * To be implemented, gets triggered when clicking on the pageTitle on the canvas.
      */
     onPageSelectionChanged = (id: Id) => {

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -75,7 +75,7 @@ interface ConfigParameterTypes {
     onZoomChanged: (scaleFactor: string) => void;
     onSelectedPageIdChanged: (pageId: string) => void;
     onPagesChanged: (pages: string) => void;
-    onPageSnapshotInvalidated: (pageId: string) => void;
+    onPageSnapshotInvalidated: (pageId: Id) => void;
     onPageSizeChanged: (scaleFactor: string) => void;
     onShapeCornerRadiusChanged: (cornerRadius: string) => void;
     onCropActiveFrameIdChanged: (id?: Id) => void;

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -56,6 +56,9 @@ interface ConfigParameterTypes {
     onFramesLayoutChanged: (state: string) => void;
     onSelectedLayoutPropertiesChanged: (state: string) => void;
     onSelectedLayoutUnitChanged: (state: string) => void;
+    /**
+     * @deprecated use `onSelectedPageIdChanged` instead
+     */
     onPageSelectionChanged: (id: Id) => void;
     onScrubberPositionChanged: (state: string) => void;
     onFrameAnimationsChanged: (state: string) => void;

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -348,10 +348,8 @@ describe('SubscriberController', () => {
     });
 
     it('should be possible to subscribe to onPageSnapshotInvalidated', async () => {
-        const pageID: Id = '123';
-
-        await mockedSubscriberController.onPageSnapshotInvalidated(JSON.stringify(pageID));
-        expect(mockEditorApi.onPageSnapshotInvalidated).toHaveBeenCalledWith(pageID);
+        await mockedSubscriberController.onPageSnapshotInvalidated('123');
+        expect(mockEditorApi.onPageSnapshotInvalidated).toHaveBeenCalledWith('123');
     });
 
     it('should be possible to subscribe to onPageSizeChanged', async () => {

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -288,7 +288,7 @@ export type InitialCallbacksConfigType = {
      *
      * @deprecated use `events.onPageSnapshotInvalidated` instead
      */
-    onPageSnapshotInvalidated?: (page: Id) => void;
+    onPageSnapshotInvalidated?: (pageId: Id) => void;
 
     /**
      * @deprecated use `events.onPageSizeChanged` instead

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -178,7 +178,7 @@ export type InitialCallbacksConfigType = {
     onSelectedFramesContentChanged?: (state: Frame[]) => void;
 
     /**
-     * @deprecated use `events.onPageSelectionChanged` instead
+     * @deprecated use `onSelectedPageIdChanged` instead
      */
     onPageSelectionChanged?: (id: Id) => void;
 


### PR DESCRIPTION
This PR

- Fix actual param we're sending for `onPageSnapshotInvalidated` to be aligned with API (eventually it's string, was a number)
- Fix the API type for `page.add` and `page.remove` methods of PageController
- Deprecate the `onPageSelectionChanged` event as not implemented from the Engine

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-2521](https://support.chili-publish.com/projects/WRS/issues/WRS-2521)

## Screenshots


[WRS-2521]: https://chilipublishintranet.atlassian.net/browse/WRS-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ