### PR TITLE
[Feature] Add layout ratio constraints

### DIFF
--- a/packages/sdk/src/controllers/LayoutController.ts
+++ b/packages/sdk/src/controllers/LayoutController.ts
@@ -6,6 +6,7 @@ import {
     LayoutIntent,
     LayoutPreset,
     ResizableLayoutPropertiesUpdate,
+    AspectRatioLayoutPropertiesUpdate,
     MeasurementUnit,
     PositionEnum,
 } from '../types/LayoutTypes';
@@ -407,6 +408,20 @@ export class LayoutController {
         const res = await this.#editorAPI;
         return res
             .setLayoutResizableByUser(id, JSON.stringify(resizableLayoutProperties))
+            .then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will set the aspect ratio of a specific layout.
+     *
+     * @param id The id of a specific layout
+     * @param aspectRatio The aspect ratio that will be used for the layout
+     * @returns
+     */
+    setAspectRatio = async (id: Id, aspectRatio: AspectRatioLayoutPropertiesUpdate) => {
+        const res = await this.#editorAPI;
+        return res
+            .setLayoutAspectRatio(id, JSON.stringify(aspectRatio))
             .then((result) => getEditorResponseData<null>(result));
     };
 }

--- a/packages/sdk/src/tests/controllers/LayoutController.test.ts
+++ b/packages/sdk/src/tests/controllers/LayoutController.test.ts
@@ -7,6 +7,7 @@ import {
     LayoutIntent,
     LayoutPreset,
     ResizableLayoutPropertiesUpdate,
+    AspectRatioLayoutPropertiesUpdate,
     MeasurementUnit,
     PositionEnum,
 } from '../../types/LayoutTypes';
@@ -48,6 +49,7 @@ const mockedEditorApi: EditorAPI = {
     setLayoutAvailableForUser: async () => getEditorResponseData(castToEditorResponse(null)),
     setLayoutSelectedByUser: async () => getEditorResponseData(castToEditorResponse(null)),
     setLayoutResizableByUser: async () => getEditorResponseData(castToEditorResponse(null)),
+    setLayoutAspectRatio: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -84,6 +86,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'setLayoutAvailableForUser');
     jest.spyOn(mockedEditorApi, 'setLayoutSelectedByUser');
     jest.spyOn(mockedEditorApi, 'setLayoutResizableByUser');
+    jest.spyOn(mockedEditorApi, 'setLayoutAspectRatio');
 
     mockId = mockSelectPage.layoutId;
 });
@@ -353,6 +356,23 @@ describe('LayoutController', () => {
         expect(mockedEditorApi.setLayoutResizableByUser).toBeCalledWith(
             '1',
             JSON.stringify(resizableLayoutPropertiesUpdate),
+        );
+    });
+
+    it('Should be possible to set the layout aspect ratio', async () => {
+        const aspectRatioLayoutPropertiesUpdate: AspectRatioLayoutPropertiesUpdate = {
+            enabled: { value: true },
+            minAspectRatioWidth: { value: '16' },
+            minAspectRatioHeight: { value: '9' },
+            maxAspectRatioWidth: { value: '4' },
+            maxAspectRatioHeight: { value: '3' },
+        };
+
+        await mockedLayoutController.setAspectRatio('1', aspectRatioLayoutPropertiesUpdate);
+        expect(mockedEditorApi.setLayoutAspectRatio).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.setLayoutAspectRatio).toBeCalledWith(
+            '1',
+            JSON.stringify(aspectRatioLayoutPropertiesUpdate),
         );
     });
 });

--- a/packages/sdk/src/types/LayoutTypes.ts
+++ b/packages/sdk/src/types/LayoutTypes.ts
@@ -67,6 +67,7 @@ export type Layout = {
     availableForUser: boolean;
     selectedByUser: boolean;
     resizableByUser: ResizableLayoutProperties;
+    aspectRatioByUser: AspectRatioLayoutProperties;
 };
 
 // used by onLayoutsChanged
@@ -155,6 +156,32 @@ export type ResizableLayoutPropertiesUpdate = {
         value: string | null;
     } | null;
     maxHeight?: {
+        value: string | null;
+    } | null;
+};
+
+export type AspectRatioLayoutProperties = {
+    enabled: boolean;
+    minAspectRatioWidth?: number | null;
+    minAspectRatioHeight?: number | null;
+    maxAspectRatioWidth?: number | null;
+    maxAspectRatioHeight?: number | null;
+};
+
+export type AspectRatioLayoutPropertiesUpdate = {
+    enabled?: {
+        value: boolean;
+    } | null;
+    minAspectRatioWidth?: {
+        value: string | null;
+    } | null;
+    minAspectRatioHeight?: {
+        value: string | null;
+    } | null;
+    maxAspectRatioWidth?: {
+        value: string | null;
+    } | null;
+    maxAspectRatioHeight?: {
         value: string | null;
     } | null;
 };


### PR DESCRIPTION
I want to clarify the model before going out from draft. Feel free to review still.

---

This PR adds a way to add layout ratio constraints given a minimum and/or a maximum ratio.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-1884
