### PR TITLE
[Fix][WRS-2644] Allow empty text stroke

### DIFF
--- a/packages/sdk/src/controllers/BrandKitController.ts
+++ b/packages/sdk/src/controllers/BrandKitController.ts
@@ -371,7 +371,7 @@ export class BrandKitController {
             const localColor = getColorById(localColors, localColorId);
             const localStrokeColor = getColorById(localColors, localStrokeColorId);
 
-            if (!localColor || !localStrokeColor)
+            if (!localColor)
                 throw new Error(`Paragraph style could not be created with an empty color: ${style.name}`);
 
             const { parsedData: styleId } = await sdk.paragraphStyle.create();


### PR DESCRIPTION
This PR allows creating a paragraph style with no text stroke to avoid breaking existing brandkits

## PR Guidelines

- [ ] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-2644](https://support.chili-publish.com/projects/WRS/issues/WRS-2644)

## Screenshots


[WRS-2644]: https://chilipublishintranet.atlassian.net/browse/WRS-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ