### PR TITLE
[Fix][WRS-2575] Throw exception on media connector download call in case of error from engine

### DIFF
--- a/packages/sdk/src/controllers/BrandKitController.ts
+++ b/packages/sdk/src/controllers/BrandKitController.ts
@@ -371,8 +371,7 @@ export class BrandKitController {
             const localColor = getColorById(localColors, localColorId);
             const localStrokeColor = getColorById(localColors, localStrokeColorId);
 
-            if (!localColor)
-                throw new Error(`Paragraph style could not be created with an empty color: ${style.name}`);
+            if (!localColor) throw new Error(`Paragraph style could not be created with an empty color: ${style.name}`);
 
             const { parsedData: styleId } = await sdk.paragraphStyle.create();
 

--- a/packages/sdk/src/controllers/MediaConnectorController.ts
+++ b/packages/sdk/src/controllers/MediaConnectorController.ts
@@ -109,9 +109,10 @@ export class MediaConnectorController {
                         {
                             success: true,
                             status: 200,
-                            data: null, // Binary data is handled via parsedData
+                            data: result,
                             parsedData: result,
-                        },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        } as any as EditorResponse<Uint8Array>,
                         false, // do not parse the response
                     );
                 }

--- a/packages/sdk/src/controllers/MediaConnectorController.ts
+++ b/packages/sdk/src/controllers/MediaConnectorController.ts
@@ -17,7 +17,7 @@ import {
     MediaDownloadIntent,
     MediaDownloadType,
 } from '../types/MediaConnectorTypes';
-import { getEditorResponseData } from '../utils/EditorResponseData';
+import { getEditorResponseData, throwEditorResponseError } from '../utils/EditorResponseData';
 
 /**
  * The MediaConnectorController is responsible for all communication regarding media connectors.
@@ -105,21 +105,12 @@ export class MediaConnectorController {
             .then((result) => {
                 // Handle binary data (Uint8Array) directly
                 if (result instanceof Uint8Array) {
-                    return getEditorResponseData<Uint8Array>(
-                        {
-                            success: true,
-                            status: 200,
-                            data: result,
-                            parsedData: result,
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        } as any as EditorResponse<Uint8Array>,
-                        false, // do not parse the response
-                    );
+                    return result;
                 }
 
-                // Handle structured response (EditorResponse)
-                if (typeof result === 'object' && result !== null && 'success' in result) {
-                    return getEditorResponseData<Uint8Array>(result as EditorResponse<Uint8Array>);
+                // Handle structured response (EditorResponse) for non-success cases
+                if (typeof result === 'object' && result !== null && 'success' in result && !result.success) {
+                    throwEditorResponseError(result as EditorResponse<null>);
                 }
 
                 // Unexpected response type - throw error

--- a/packages/sdk/src/controllers/MediaConnectorController.ts
+++ b/packages/sdk/src/controllers/MediaConnectorController.ts
@@ -93,11 +93,12 @@ export class MediaConnectorController {
         mediaId: Id,
         downloadType: MediaDownloadType,
         context: MetaData = {},
-    ): Promise<Uint8Array> => {
+    )=> {
         const compatibleDownloadType = this.parseDeprecatedMediaDownloadType(
             downloadType as unknown as DeprecatedMediaConnectorDownloadType,
         ) as MediaDownloadType;
         const res = await this.#blobAPI;
+        // .then((result) => getEditorResponseData<null>(result));
         return res
             .mediaConnectorDownload(
                 id,
@@ -106,7 +107,18 @@ export class MediaConnectorController {
                 MediaDownloadIntent.web,
                 JSON.stringify(context),
             )
-            .then((result) => (result as Uint8Array) ?? (result as EditorResponse<null>));
+            .then((result) => {
+                if ('success' in (result as EditorResponse<null>)) {
+                    return getEditorResponseData<null>(result as EditorResponse<null>)
+                } else {
+                    const editorResponseWrapper = {
+                        success: true,
+                        status: 200,
+                        parsedData: result,
+                    }
+                    return editorResponseWrapper;
+                }
+            });
     };
 
     /**

--- a/packages/sdk/src/controllers/MediaConnectorController.ts
+++ b/packages/sdk/src/controllers/MediaConnectorController.ts
@@ -103,20 +103,26 @@ export class MediaConnectorController {
                 JSON.stringify(context),
             )
             .then((result) => {
+                // Handle binary data (Uint8Array) directly
                 if (result instanceof Uint8Array) {
                     return getEditorResponseData<Uint8Array>(
                         {
                             success: true,
                             status: 200,
-                            data: result,
-                        } as any as EditorResponse<Uint8Array>,
-                        // do not parse the response
-                        false,
+                            data: null, // Binary data is handled via parsedData
+                            parsedData: result,
+                        },
+                        false, // do not parse the response
                     );
-                } else {
-                    // throw exception when response is not of type Uint8Array
+                }
+
+                // Handle structured response (EditorResponse)
+                if (typeof result === 'object' && result !== null && 'success' in result) {
                     return getEditorResponseData<Uint8Array>(result as EditorResponse<Uint8Array>);
                 }
+
+                // Unexpected response type - throw error
+                throw new Error(`Unexpected response type: ${typeof result}.`);
             });
     };
 


### PR DESCRIPTION
This PR throws an exception on media connector download call in case of error from engine

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

-   [WRS-2575](https://support.chili-publish.com/projects/WRS/issues/WRS-2575)

## Screenshots


[WRS-2575]: https://chilipublishintranet.atlassian.net/browse/WRS-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ