### PR TITLE
[Fix] [WRS-2970] Fix build doc run on releas creation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -292,6 +292,7 @@ jobs:
       pull-requests: read
     outputs:
       notification_text: ${{ steps.create_release_and_notify.outputs.notification_text }}
+      version_commit_sha: ${{ steps.apply_version.outputs.version_commit_sha }}
     steps:
       - name: Validate branch
         run: |
@@ -422,6 +423,8 @@ jobs:
     needs: [production]
     if: needs.production.result == 'success'
     uses: ./.github/workflows/publish-docs.yml
+    with:
+      release_commit_sha: ${{ needs.production.outputs.version_commit_sha }}
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -292,7 +292,6 @@ jobs:
       pull-requests: read
     outputs:
       notification_text: ${{ steps.create_release_and_notify.outputs.notification_text }}
-      version_commit_sha: ${{ steps.apply_version.outputs.version_commit_sha }}
     steps:
       - name: Validate branch
         run: |
@@ -418,18 +417,6 @@ jobs:
           target_branch: ${{ needs.configure-parameters.outputs.target_branch }}
         env:
           GITHUB_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
-
-  publish-docs:
-    needs: [production]
-    if: needs.production.result == 'success'
-    uses: ./.github/workflows/publish-docs.yml
-    with:
-      release_commit_sha: ${{ needs.production.outputs.version_commit_sha }}
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-      packages: read
 
   notify-teams:
     needs: [configure-parameters, uat-regular, uat-hotfix, production]

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -418,6 +418,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
 
+  publish-docs:
+    needs: [production]
+    if: needs.production.result == 'success'
+    uses: ./.github/workflows/publish-docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      packages: read
+
   notify-teams:
     needs: [configure-parameters, uat-regular, uat-hotfix, production]
     if: always() && (needs.uat-regular.result == 'success' || needs.uat-hotfix.result == 'success' || needs.production.result == 'success')

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -321,6 +321,18 @@ jobs:
               --overwrite true \
               --auth-mode login
 
+  publish-docs:
+    needs: [validate-tag-release, detect-release-type, preflight]
+    if: needs.validate-tag-release.outputs.release_exists == 'true' && needs.detect-release-type.outputs.is_prd == 'true'
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      release_commit_sha: ${{ needs.detect-release-type.outputs.tag_name }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      packages: read
+
   purge-cdn:
     needs: [validate-tag-release, detect-release-type, deploy-azure]
     if: needs.validate-tag-release.outputs.release_exists == 'true'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,11 @@ on:
 
   # Allows other workflows to call this workflow
   workflow_call:
+    inputs:
+      release_commit_sha:
+        description: "The commit SHA of the release to check out"
+        required: false
+        type: string
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -35,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_commit_sha || github.sha }}
       - name: Check cache
         id: cache
         uses: actions/cache@v4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Allows other workflows to call this workflow
+  workflow_call:
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read


### PR DESCRIPTION
This PR fixes the build docs workflow, that was no longer running after the creation of a release.

The problem is related to  the usage of `GITHUB_TOKEN`. When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run. Check the docs [here](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
).

The issue was that `create-gh-release` action creates the release using `GH_TOKEN: ${{ env.GITHUB_TOKEN }}` which mean any release event (including `released` that we use) emitted by that action is ignored by GitHub, so no downstream workflow will ever be triggered.

The solution was to make the `Publish Docs` callable and call it after the release was done.
## PR Guidelines

- [ ] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

- [WRS-2970](https://chilipublishintranet.atlassian.net/browse/WRS-2970)

## Screenshots


[WRS-2970]: https://chilipublishintranet.atlassian.net/browse/WRS-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ