### PR TITLE
[Fix] Add onInjectedDataChanged stream

### DIFF
--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -422,6 +422,15 @@ export class SubscriberController {
     };
 
     /**
+     * Listener on when injected data has changed
+     *
+     * @param variableId the id of the injected data source variable
+     */
+    onInjectedDataChanged = (variableId: Id) => {
+        this.config.events.onInjectedDataChanged.trigger(variableId);
+    };
+
+    /**
      * Listener on document issues, if this changes, this listener will get triggered with the updates
      * @param documentIssues Stringified object of document issues
      */

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -133,6 +133,7 @@ interface ConfigParameterTypes {
     onViewModeChanged: (viewMode: string) => void;
     onBarcodeValidationChanged: (validationResults: string) => void;
     onDataSourceIdChanged: (connectorId?: Id) => void;
+    onInjectedDataChanged: (variableId: Id) => void;
     onDocumentIssueListChanged: (documentIssues: string) => void;
     onCustomUndoDataChanged: (customData: string) => void;
     onEngineEditModeChanged: (engineEditMode: string) => void;
@@ -250,6 +251,7 @@ const Connect = (
                 barcodeValidationChanged: params.onBarcodeValidationChanged,
                 selectedPageIdChanged: params.onSelectedPageIdChanged,
                 dataSourceIdChanged: params.onDataSourceIdChanged,
+                injectedDataChanged: params.onInjectedDataChanged,
                 documentIssueListChanged: params.onDocumentIssueListChanged,
                 customUndoDataChanged: params.onCustomUndoDataChanged,
                 engineEditingModeChanged: params.onEngineEditModeChanged,

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -221,6 +221,7 @@ export class SDK {
                 onViewModeChanged: this.subscriber.onViewModeChanged,
                 onBarcodeValidationChanged: this.subscriber.onBarcodeValidationChanged,
                 onDataSourceIdChanged: this.subscriber.onDataSourceIdChanged,
+                onInjectedDataChanged: this.subscriber.onInjectedDataChanged,
                 onDocumentIssueListChanged: this.subscriber.onDocumentIssueListChanged,
                 onCustomUndoDataChanged: this.subscriber.onCustomUndoDataChanged,
                 onEngineEditModeChanged: this.subscriber.onEngineEditModeChanged,

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -85,6 +85,7 @@ const mockEditorApi: EditorAPI = {
     onViewportRequested: async () => getEditorResponseData(castToEditorResponse(null)),
     onBarcodeValidationChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onDataSourceIdChanged: async () => getEditorResponseData(castToEditorResponse(null)),
+    onInjectedDataChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onDocumentIssueListChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onEngineEditModeChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onBrandKitMediaChanged: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -132,6 +133,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'onBarcodeValidationChanged');
     jest.spyOn(mockEditorApi, 'onViewportRequested');
     jest.spyOn(mockEditorApi, 'onDataSourceIdChanged');
+    jest.spyOn(mockEditorApi, 'onInjectedDataChanged');
     jest.spyOn(mockEditorApi, 'onDocumentIssueListChanged');
     jest.spyOn(mockEditorApi, 'onEngineEditModeChanged');
     jest.spyOn(mockEditorApi, 'onBrandKitMediaChanged');
@@ -554,6 +556,14 @@ describe('SubscriberController', () => {
 
         expect(mockEditorApi.onDataSourceIdChanged).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.onDataSourceIdChanged).toHaveBeenCalledWith(connectorId);
+    });
+
+    it('should be possible to subscribe to onInjectedDataChanged', async () => {
+        const variableId: Id = 'injected-data-source-var-1';
+        await mockedSubscriberController.onInjectedDataChanged(variableId);
+
+        expect(mockEditorApi.onInjectedDataChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onInjectedDataChanged).toHaveBeenCalledWith(variableId);
     });
 
     it('should be possible to subscribe to onDocumentIssueListChanged', async () => {

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -126,6 +126,7 @@ export type ManagedCallbacksConfigType = {
             (validationResults: BarcodeFrameValidationResult[]) => MaybePromise<void>
         >;
         onDataSourceIdChanged: EngineEvent<(connectorId?: Id) => MaybePromise<void>>;
+        onInjectedDataChanged: EngineEvent<(variableId: Id) => MaybePromise<void>>;
         onDocumentIssueListChanged: EngineEvent<(documentIssues: DocumentIssue[]) => MaybePromise<void>>;
         onCustomUndoDataChanged: EngineEvent<(customData: Record<string, string>) => MaybePromise<void>>;
         onEngineEditModeChanged: EngineEvent<(engineEditMode: EngineEditMode) => MaybePromise<void>>;
@@ -332,6 +333,11 @@ export type InitialCallbacksConfigType = {
      * @deprecated use `events.onDataSourceIdChanged` instead
      */
     onDataSourceIdChanged?: (connectorId?: Id) => void;
+
+    /**
+     * @deprecated use `events.onInjectedDataChanged` instead
+     */
+    onInjectedDataChanged?: (variableId: Id) => void;
 
     /**
      * @deprecated use `events.onDocumentIssueListChanged` instead

--- a/packages/sdk/src/utils/ConfigHelper.ts
+++ b/packages/sdk/src/utils/ConfigHelper.ts
@@ -204,6 +204,10 @@ export class ConfigHelper {
                 () => clone.onDataSourceIdChanged,
                 clone.logging.logger,
             ),
+            onInjectedDataChanged: new EngineEvent<(variableId: Id) => MaybePromise<void>>(
+                () => clone.onInjectedDataChanged,
+                clone.logging.logger,
+            ),
             onDocumentIssueListChanged: new EngineEvent<(documentIssues: DocumentIssue[]) => MaybePromise<void>>(
                 () => clone.onDocumentIssueListChanged,
                 clone.logging.logger,


### PR DESCRIPTION
This PR adds a `onInjectedDataChanged` stream that notifies whenever dsv injected data has changed.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-2423