### PR TITLE
[Fix] Updated AuthRefreshRequest to support non-connector token refresh

### DIFF
--- a/examples/sdk/auth-expiration-typescript-example/src/authExpiredHandler.ts
+++ b/examples/sdk/auth-expiration-typescript-example/src/authExpiredHandler.ts
@@ -39,16 +39,6 @@ export const createOnAuthExpiredHandler = (
   };
 };
 
-const sampleConnectorDefinitionStatic = {
-  id: "sample-connector",
-  name: "Sample media connector",
-  type: ConnectorType.media,
-  supportedAuthentication: {
-    browser: [ConnectorSupportedAuth.StaticKey],
-    server: [ConnectorSupportedAuth.StaticKey],
-  },
-};
-
 const sampleConnectorDefinitionNone = {
   id: "sample-connector-none",
   name: "Sample media connector",
@@ -60,11 +50,7 @@ const sampleConnectorDefinitionNone = {
 };
 
 export const mockGrafxTokenRefreshRequest = (): AuthRefreshRequest => ({
-  connectorId: "local-connector-id",
-  remoteConnectorId: "remote-connector-id",
   type: AuthRefreshTypeEnum.grafxToken,
-  headerValue: null,
-  connectorDefinition: sampleConnectorDefinitionStatic,
 });
 
 export const mockBrowserNoneInjectionRequest = (): AuthRefreshRequest => ({

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -411,19 +411,7 @@ describe('SubscriberController', () => {
         const staticHeaderValue = 'Static, 1234';
 
         const grafxAuthRefreshRequest: AuthRefreshRequest = {
-            connectorId: connectorId,
-            remoteConnectorId: remoteConnectorId,
             type: AuthRefreshTypeEnum.grafxToken,
-            headerValue: null,
-            connectorDefinition: {
-                id: 'connectorId',
-                name: 'connectorName',
-                type: ConnectorType.media,
-                supportedAuthentication: {
-                    browser: [ConnectorSupportedAuth.StaticKey],
-                    server: [ConnectorSupportedAuth.StaticKey],
-                },
-            },
         };
 
         const anyAuthRefreshRequest: AuthRefreshRequest = {

--- a/packages/sdk/src/types/ConnectorTypes.ts
+++ b/packages/sdk/src/types/ConnectorTypes.ts
@@ -317,23 +317,28 @@ export enum AuthRefreshTypeEnum {
     any = 'any',
 }
 
+export type GrafxAuthRefreshRequest = {
+    type: AuthRefreshTypeEnum.grafxToken;
+};
+
 /**
  * @param connectorId connector id
  * @param remoteConnectorId remote connector id
- * @param type type of auth renewal needed
  * @param headerValue the value of the X-GRAFX-UNAUTHORIZED header. This
  *      will notify that the dam authentication expired if it went through the
  *      proxy.
  *      Example: "Static, 1234", "OAuthClientCredentials, 5678"
  *      If the http request did not go through the proxy, headerValue is null.
  */
-export type AuthRefreshRequest = {
+export type AnyAuthRefreshRequest = {
+    type: AuthRefreshTypeEnum.any;
     connectorId: Id;
     remoteConnectorId: Id;
-    type: AuthRefreshTypeEnum;
     headerValue: string | null;
     connectorDefinition: ConnectorDefinition;
 };
+
+export type AuthRefreshRequest = GrafxAuthRefreshRequest | AnyAuthRefreshRequest;
 
 export type ConnectorOptions = ContextDictionary;
 export type MetaData = ContextDictionary;


### PR DESCRIPTION
This PR supports token refresh for any http call.

💡This is breaking because we cannot fill connector related fields anymore.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-2441