### PR TITLE
[EDT-2470] [Fix] Add columnName to ExceptionContext

### DIFF
--- a/packages/sdk/src/exceptions/AsyncExceptions.ts
+++ b/packages/sdk/src/exceptions/AsyncExceptions.ts
@@ -18,6 +18,7 @@ enum AsyncErrorType {
 
 interface ExceptionContext {
     variableId?: Id;
+    columnName?: string;
 }
 
 interface EditorExceptionDto {

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -39,6 +39,7 @@ import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorR
 import { ToolType } from '../../utils/Enums';
 import { mockBaseUrl, mockLocalConfig } from '../__mocks__/localConfig';
 import { EngineEditModeType } from '../../types/EngineEditModeTypes';
+import { DataRowAsyncError } from '../../exceptions';
 
 let mockedAnimation: FrameAnimationType;
 let mockedSubscriberController: SubscriberController;
@@ -403,6 +404,36 @@ describe('SubscriberController', () => {
 
         expect(mockEditorApi.onAsyncError).toHaveBeenCalledTimes(1);
         expect(mockEditorApi.onAsyncError).toHaveBeenCalledWith(asyncError);
+    });
+
+    it('Should parse dataRow async errors into DataRowAsyncError with column metadata in exception context', async () => {
+        const asyncError = {
+            type: 'dataRow',
+            count: 1,
+            message: 'Data row error',
+            exceptions: [
+                {
+                    type: 'VariableException',
+                    code: 403032,
+                    message: 'Invalid value',
+                    context: {
+                        variableId: 'var-1',
+                        columnName: 'email',
+                    },
+                },
+            ],
+        };
+        await mockedSubscriberController.onAsyncError(JSON.stringify(asyncError));
+
+        expect(mockEditorApi.onAsyncError).toHaveBeenCalledTimes(1);
+        const error = (mockEditorApi.onAsyncError as jest.Mock).mock.calls[0][0];
+        expect(error).toBeInstanceOf(DataRowAsyncError);
+        expect(error.count).toBe(1);
+        expect(error.message).toBe('Data row error');
+        expect(error.exceptions[0].context).toEqual({
+            variableId: 'var-1',
+            columnName: 'email',
+        });
     });
 
     describe('onAuthExpired', () => {


### PR DESCRIPTION
This PR adds a new columnName property to ExceptionContext

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-2470
https://chilipublishintranet.atlassian.net/browse/WRS-3097
