### PR TITLE
[Feature] [EDT-2458] Add `onCanvasFramesManipulated` event

### DIFF
--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -460,7 +460,7 @@ export class SubscriberController {
      * programmatic changes do not trigger this event.
      * @param frameIds Stringified array of frame Id strings
      */
-    onFramesManipulatedOnCanvas = (frameIds: string) => {
-        this.config.events.onFramesManipulatedOnCanvas.trigger(JSON.parse(frameIds));
+    onCanvasFramesManipulated = (frameIds: string) => {
+        this.config.events.onCanvasFramesManipulated.trigger(JSON.parse(frameIds));
     };
 }

--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -455,7 +455,7 @@ export class SubscriberController {
     };
 
     /**
-     * Listener that fires when frames are manipulated (e.g. moved, resized, rotated, cropped) by the user.
+     * Listener that fires when frames are manipulated (e.g. moved, resized, rotated, cropped, text changed) by the user.
      * Note: this event only fires when the manipulation was caused by direct user interaction on the canvas;
      * programmatic changes do not trigger this event.
      * @param frameIds Stringified array of frame Id strings

--- a/packages/sdk/src/controllers/SubscriberController.ts
+++ b/packages/sdk/src/controllers/SubscriberController.ts
@@ -453,4 +453,14 @@ export class SubscriberController {
     onBrandKitMediaChanged = (brandKitMedia: string) => {
         this.config.events.onBrandKitMediaChanged.trigger(JSON.parse(brandKitMedia));
     };
+
+    /**
+     * Listener that fires when frames are manipulated (e.g. moved, resized, rotated, cropped) by the user.
+     * Note: this event only fires when the manipulation was caused by direct user interaction on the canvas;
+     * programmatic changes do not trigger this event.
+     * @param frameIds Stringified array of frame Id strings
+     */
+    onFramesManipulatedOnCanvas = (frameIds: string) => {
+        this.config.events.onFramesManipulatedOnCanvas.trigger(JSON.parse(frameIds));
+    };
 }

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -138,7 +138,7 @@ interface ConfigParameterTypes {
     onCustomUndoDataChanged: (customData: string) => void;
     onEngineEditModeChanged: (engineEditMode: string) => void;
     onBrandKitMediaChanged: (brandKitMedia: string) => void;
-    onFramesManipulatedOnCanvas: (frameIds: string) => void;
+    onCanvasFramesManipulated: (frameIds: string) => void;
 }
 
 let messageHandler: ((event: MessageEvent) => void) | null = null;
@@ -257,7 +257,7 @@ const Connect = (
                 customUndoDataChanged: params.onCustomUndoDataChanged,
                 engineEditingModeChanged: params.onEngineEditModeChanged,
                 brandKitMediaChanged: params.onBrandKitMediaChanged,
-                frameManipulated: params.onFramesManipulatedOnCanvas,
+                frameManipulated: params.onCanvasFramesManipulated,
             },
         }),
     );

--- a/packages/sdk/src/interactions/Connector.ts
+++ b/packages/sdk/src/interactions/Connector.ts
@@ -138,6 +138,7 @@ interface ConfigParameterTypes {
     onCustomUndoDataChanged: (customData: string) => void;
     onEngineEditModeChanged: (engineEditMode: string) => void;
     onBrandKitMediaChanged: (brandKitMedia: string) => void;
+    onFramesManipulatedOnCanvas: (frameIds: string) => void;
 }
 
 let messageHandler: ((event: MessageEvent) => void) | null = null;
@@ -256,6 +257,7 @@ const Connect = (
                 customUndoDataChanged: params.onCustomUndoDataChanged,
                 engineEditingModeChanged: params.onEngineEditModeChanged,
                 brandKitMediaChanged: params.onBrandKitMediaChanged,
+                frameManipulated: params.onFramesManipulatedOnCanvas,
             },
         }),
     );

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -262,7 +262,7 @@ export class SDK {
                 onCustomUndoDataChanged: this.subscriber.onCustomUndoDataChanged,
                 onEngineEditModeChanged: this.subscriber.onEngineEditModeChanged,
                 onBrandKitMediaChanged: this.subscriber.onBrandKitMediaChanged,
-                onFramesManipulatedOnCanvas: this.subscriber.onFramesManipulatedOnCanvas,
+                onCanvasFramesManipulated: this.subscriber.onCanvasFramesManipulated,
             },
             this.setConnection,
             this.config.editorId,

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -262,6 +262,7 @@ export class SDK {
                 onCustomUndoDataChanged: this.subscriber.onCustomUndoDataChanged,
                 onEngineEditModeChanged: this.subscriber.onEngineEditModeChanged,
                 onBrandKitMediaChanged: this.subscriber.onBrandKitMediaChanged,
+                onFramesManipulatedOnCanvas: this.subscriber.onFramesManipulatedOnCanvas,
             },
             this.setConnection,
             this.config.editorId,

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -91,7 +91,7 @@ const mockEditorApi: EditorAPI = {
     onDocumentIssueListChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onEngineEditModeChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onBrandKitMediaChanged: async () => getEditorResponseData(castToEditorResponse(null)),
-    onFramesManipulatedOnCanvas: async () => getEditorResponseData(castToEditorResponse(null)),
+    onCanvasFramesManipulated: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -611,10 +611,10 @@ describe('SubscriberController', () => {
         expect(mockEditorApi.onBrandKitMediaChanged).toHaveBeenCalledWith({});
     });
 
-    it('Should call onFramesManipulatedOnCanvas subscriber with parsed frame ids when triggered', async () => {
+    it('Should call onCanvasFramesManipulated subscriber with parsed frame ids when triggered', async () => {
         const callback = jest.fn();
-        mockedConfig.events.onFramesManipulatedOnCanvas.registerCallback(callback);
-        await mockedSubscriberController.onFramesManipulatedOnCanvas(JSON.stringify(['frame-1', 'frame-2']));
+        mockedConfig.events.onCanvasFramesManipulated.registerCallback(callback);
+        await mockedSubscriberController.onCanvasFramesManipulated(JSON.stringify(['frame-1', 'frame-2']));
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith(['frame-1', 'frame-2']);
     });

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -20,7 +20,7 @@ import { FrameAnimationType } from '../../types/AnimationTypes';
 import { VariableType } from '../../types/VariableTypes';
 
 import * as Next from '../../next/types/ConnectorTypes';
-import { EditorAPI } from '../../types/CommonTypes';
+import { EditorAPI, RuntimeConfigType } from '../../types/CommonTypes';
 import {
     AuthCredentials,
     AuthCredentialsTypeEnum,
@@ -43,6 +43,7 @@ import { DataRowAsyncError } from '../../exceptions';
 
 let mockedAnimation: FrameAnimationType;
 let mockedSubscriberController: SubscriberController;
+let mockedConfig: RuntimeConfigType;
 
 const mockEditorApi: EditorAPI = {
     onAnimationChanged: async () => getEditorResponseData(castToEditorResponse(null)),
@@ -90,6 +91,7 @@ const mockEditorApi: EditorAPI = {
     onDocumentIssueListChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onEngineEditModeChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onBrandKitMediaChanged: async () => getEditorResponseData(castToEditorResponse(null)),
+    onFramesManipulatedOnCanvas: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -139,10 +141,8 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'onEngineEditModeChanged');
     jest.spyOn(mockEditorApi, 'onBrandKitMediaChanged');
 
-    mockedSubscriberController = new SubscriberController(
-        ConfigHelper.createRuntimeConfig(mockEditorApi),
-        mockLocalConfig,
-    );
+    mockedConfig = ConfigHelper.createRuntimeConfig(mockEditorApi);
+    mockedSubscriberController = new SubscriberController(mockedConfig, mockLocalConfig);
     mockedAnimation = mockFrameAnimation;
 });
 
@@ -609,5 +609,13 @@ describe('SubscriberController', () => {
         await mockedSubscriberController.onBrandKitMediaChanged(JSON.stringify({}));
         expect(mockEditorApi.onBrandKitMediaChanged).toHaveBeenCalled();
         expect(mockEditorApi.onBrandKitMediaChanged).toHaveBeenCalledWith({});
+    });
+
+    it('Should call onFramesManipulatedOnCanvas subscriber with parsed frame ids when triggered', async () => {
+        const callback = jest.fn();
+        mockedConfig.events.onFramesManipulatedOnCanvas.registerCallback(callback);
+        await mockedSubscriberController.onFramesManipulatedOnCanvas(JSON.stringify(['frame-1', 'frame-2']));
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(['frame-1', 'frame-2']);
     });
 });

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -133,8 +133,8 @@ export type ManagedCallbacksConfigType = {
         onEngineEditModeChanged: EngineEvent<(engineEditMode: EngineEditMode) => MaybePromise<void>>;
         onBrandKitMediaChanged: EngineEvent<(brandKitMedia: BrandKitMedia[]) => MaybePromise<void>>;
         /**
-         * Fires when frames are manipulated (e.g. moved, resized, rotated).
-         * Note: this event only fires when the manipulation was caused by direct user interaction;
+         * Listener that fires when frames are manipulated (e.g. moved, resized, rotated, cropped, text changed) by the user.
+         * Note: this event only fires when the manipulation was caused by direct user interaction on the canvas;
          * programmatic changes do not trigger this event.
          */
         onCanvasFramesManipulated: EngineEvent<(frameIds: Id[]) => MaybePromise<void>>;

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -132,6 +132,12 @@ export type ManagedCallbacksConfigType = {
         onCustomUndoDataChanged: EngineEvent<(customData: Record<string, string>) => MaybePromise<void>>;
         onEngineEditModeChanged: EngineEvent<(engineEditMode: EngineEditMode) => MaybePromise<void>>;
         onBrandKitMediaChanged: EngineEvent<(brandKitMedia: BrandKitMedia[]) => MaybePromise<void>>;
+        /**
+         * Fires when frames are manipulated (e.g. moved, resized, rotated).
+         * Note: this event only fires when the manipulation was caused by direct user interaction;
+         * programmatic changes do not trigger this event.
+         */
+        onFramesManipulatedOnCanvas: EngineEvent<(frameIds: Id[]) => MaybePromise<void>>;
     };
 };
 
@@ -359,6 +365,11 @@ export type InitialCallbacksConfigType = {
      * @deprecated use `events.onBrandKitMediaChanged` instead
      */
     onBrandKitMediaChanged?: (brandKitMedia: BrandKitMedia[]) => void;
+
+    /**
+     * @deprecated use `events.onFramesManipulatedOnCanvas` instead
+     */
+    onFramesManipulatedOnCanvas?: (frameIds: Id[]) => void;
 };
 
 export type ConfigType = InitialCallbacksConfigType & BaseConfigType;

--- a/packages/sdk/src/types/CommonTypes.ts
+++ b/packages/sdk/src/types/CommonTypes.ts
@@ -137,7 +137,7 @@ export type ManagedCallbacksConfigType = {
          * Note: this event only fires when the manipulation was caused by direct user interaction;
          * programmatic changes do not trigger this event.
          */
-        onFramesManipulatedOnCanvas: EngineEvent<(frameIds: Id[]) => MaybePromise<void>>;
+        onCanvasFramesManipulated: EngineEvent<(frameIds: Id[]) => MaybePromise<void>>;
     };
 };
 
@@ -367,9 +367,9 @@ export type InitialCallbacksConfigType = {
     onBrandKitMediaChanged?: (brandKitMedia: BrandKitMedia[]) => void;
 
     /**
-     * @deprecated use `events.onFramesManipulatedOnCanvas` instead
+     * @deprecated use `events.onCanvasFramesManipulated` instead
      */
-    onFramesManipulatedOnCanvas?: (frameIds: Id[]) => void;
+    onCanvasFramesManipulated?: (frameIds: Id[]) => void;
 };
 
 export type ConfigType = InitialCallbacksConfigType & BaseConfigType;

--- a/packages/sdk/src/utils/ConfigHelper.ts
+++ b/packages/sdk/src/utils/ConfigHelper.ts
@@ -224,6 +224,10 @@ export class ConfigHelper {
                 () => clone.onBrandKitMediaChanged,
                 clone.logging.logger,
             ),
+            onFramesManipulatedOnCanvas: new EngineEvent<(frameIds: Id[]) => MaybePromise<void>>(
+                () => clone.onFramesManipulatedOnCanvas,
+                clone.logging.logger,
+            ),
         };
         return clone;
     }

--- a/packages/sdk/src/utils/ConfigHelper.ts
+++ b/packages/sdk/src/utils/ConfigHelper.ts
@@ -224,8 +224,8 @@ export class ConfigHelper {
                 () => clone.onBrandKitMediaChanged,
                 clone.logging.logger,
             ),
-            onFramesManipulatedOnCanvas: new EngineEvent<(frameIds: Id[]) => MaybePromise<void>>(
-                () => clone.onFramesManipulatedOnCanvas,
+            onCanvasFramesManipulated: new EngineEvent<(frameIds: Id[]) => MaybePromise<void>>(
+                () => clone.onCanvasFramesManipulated,
                 clone.logging.logger,
             ),
         };


### PR DESCRIPTION
This PR adds `onCanvasFramesManipulated` event. 

This event will only trigger when the user interacts with the frames on the engine canvas (move, resize, rotate, crop, text changed).

## Related tickets

- https://chilipublishintranet.atlassian.net/browse/EDT-2458
