### PR TITLE
:sparkles: [EDT-2482] Expose missing properties and types for custom shapes

### DIFF
--- a/packages/sdk/src/types/ComponentGridTypes.ts
+++ b/packages/sdk/src/types/ComponentGridTypes.ts
@@ -11,7 +11,7 @@ export type ComponentGridSettingsDeltaUpdate = {
     rowGap?: {
         value: string;
     };
-}
+};
 
 export enum ComponentGridLayoutAlgorithm {
     fixed = 'fixed',
@@ -25,4 +25,4 @@ export type FixedComponentGridSettings = {
     rowGap: number;
 };
 
-export type ComponentGridSettings = FixedComponentGridSettings /* | More will be added later */; 
+export type ComponentGridSettings = FixedComponentGridSettings /* | More will be added later */;

--- a/packages/sdk/src/types/FrameTypes.ts
+++ b/packages/sdk/src/types/FrameTypes.ts
@@ -208,7 +208,7 @@ export type ComponentGridFrame = {
 
 export type GridVariableMapping = {
     mappings: Record<string, VariableMapping[] | null>;
-}
+};
 
 export type ComponentSource = ConnectorComponentSource;
 

--- a/packages/sdk/src/types/MethodInvocationTypes.ts
+++ b/packages/sdk/src/types/MethodInvocationTypes.ts
@@ -34,6 +34,6 @@ export type Instrumented<T> = {
     [K in keyof T]: T[K] extends (...args: any[]) => any
         ? MethodListenable<T[K]>
         : T[K] extends object
-          ? Instrumented<T[K]>
-          : T[K];
+        ? Instrumented<T[K]>
+        : T[K];
 };

--- a/packages/sdk/src/types/RichTextRuleTypes.ts
+++ b/packages/sdk/src/types/RichTextRuleTypes.ts
@@ -44,7 +44,6 @@ export interface LineBreakTextStyleRule {
     styleKind: StructuredTextStyleKind.lineBreak;
 }
 
-
 /**
  * A style rule that applies inline character styling directly to matched
  * elements without requiring a named style.

--- a/packages/sdk/src/types/ShapeTypes.ts
+++ b/packages/sdk/src/types/ShapeTypes.ts
@@ -4,6 +4,7 @@ export enum ShapeType {
     ellipse = 'ellipse',
     rectangle = 'rectangle',
     polygon = 'polygon',
+    custom = 'custom',
 }
 
 export interface ShapeProperties {
@@ -71,4 +72,18 @@ export type ShapeFramePolygonSource = {
     cornerRadius?: CornerRadius;
 };
 
-export type ShapeFrameSource = ShapeFrameRectSource | ShapeFrameEllipseSource | ShapeFramePolygonSource;
+export type ShapeFrameCustomSource = {
+    type: ShapeType.custom;
+    /**  
+     * The shape path is in relative coordinates to the frame, 
+     * with the top left corner of the frame being (0, 0) and the 
+     * bottom right corner being (1, 1). The path should be a valid SVG path string. 
+     */
+    path: string;
+};
+
+export type ShapeFrameSource =
+    | ShapeFrameRectSource
+    | ShapeFrameEllipseSource
+    | ShapeFramePolygonSource
+    | ShapeFrameCustomSource;


### PR DESCRIPTION
This PR exposes custom as a shape type as this is being exposed now via image clipping paths

## PR Guidelines

- [X] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

- [EDT-2482](https://chilipublishintranet.atlassian.net/browse/EDT-2482)

## Screenshots


[EDT-2482]: https://chilipublishintranet.atlassian.net/browse/EDT-2482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ