### PR TITLE
[Fix][WRS-3102] Use freshest auth token on stageFiles endpoint

### DIFF
--- a/packages/sdk/src/controllers/UtilsController.ts
+++ b/packages/sdk/src/controllers/UtilsController.ts
@@ -10,7 +10,6 @@ import { getEditorResponseData } from '../utils/EditorResponseData';
 import { EnvironmentType } from '../utils/Enums';
 import { round } from '../utils/MathUtils';
 import { MeasurementUnit } from '../types/LayoutTypes';
-import { ConfigurationController } from './ConfigurationController';
 
 /**
  * The UtilsController exposes a set of useful utilities that can be used to make some repeated tasks a bit easier

--- a/packages/sdk/src/controllers/UtilsController.ts
+++ b/packages/sdk/src/controllers/UtilsController.ts
@@ -10,6 +10,7 @@ import { getEditorResponseData } from '../utils/EditorResponseData';
 import { EnvironmentType } from '../utils/Enums';
 import { round } from '../utils/MathUtils';
 import { MeasurementUnit } from '../types/LayoutTypes';
+import { ConfigurationController } from './ConfigurationController';
 
 /**
  * The UtilsController exposes a set of useful utilities that can be used to make some repeated tasks a bit easier
@@ -69,7 +70,10 @@ export class UtilsController {
 
         const stageUrl = `${envApiUrl}connectors/${remoteConnectorId}/stage`;
 
-        const accessToken = this.#localConfig.get(WellKnownConfigurationKeys.GraFxStudioAuthToken);
+        // fetch the freshest access token
+        const res = await this.#editorAPI;
+        const accessTokenResult = await res.getConfigValue(WellKnownConfigurationKeys.GraFxStudioAuthToken);
+        const accessToken = getEditorResponseData<string>(accessTokenResult)?.parsedData;
         if (!accessToken) {
             throw new Error('GraFx Studio Auth Token is not set');
         }

--- a/packages/sdk/src/tests/controllers/UtilsController.test.ts
+++ b/packages/sdk/src/tests/controllers/UtilsController.test.ts
@@ -14,13 +14,13 @@ global.fetch = mockFetch;
 
 const mockedEditorApi: EditorAPI = {
     unitEvaluate: jest.fn().mockResolvedValue(castToEditorResponse(null)),
+    getConfigValue: jest.fn().mockResolvedValue(castToEditorResponse('GRAFX_AUTH_TOKEN')),
 };
 
 const mockedLocalConfig = new Map<string, string>();
 beforeEach(() => {
     jest.spyOn(MathUtils, 'round');
     mockedLocalConfig.set(WellKnownConfigurationKeys.GraFxStudioEnvironmentApiUrl, 'ENVIRONMENT_API/');
-    mockedLocalConfig.set(WellKnownConfigurationKeys.GraFxStudioAuthToken, 'GRAFX_AUTH_TOKEN');
     mockedUtilsController = new UtilsController(mockedEditorApi, mockedLocalConfig);
 });
 
@@ -84,6 +84,9 @@ describe('UtilsController', () => {
     });
 
     describe('stageFiles', () => {
+        beforeEach(() => {
+            (mockedEditorApi.getConfigValue as jest.Mock).mockResolvedValue(castToEditorResponse('GRAFX_AUTH_TOKEN'));
+        });
         it('should call the stageFiles method with a blob', async () => {
             mockFetch.mockResolvedValue({
                 ok: true,
@@ -123,7 +126,7 @@ describe('UtilsController', () => {
             );
         });
         it('should throw when stageFiles is called without configured auth token  ', async () => {
-            mockedLocalConfig.delete(WellKnownConfigurationKeys.GraFxStudioAuthToken);
+            (mockedEditorApi.getConfigValue as jest.Mock).mockResolvedValue(castToEditorResponse(undefined));
             await expect(
                 mockedUtilsController.stageFiles(
                     [new File(['test'], 'test.jpg', { type: 'image/jpeg' })],
@@ -144,6 +147,7 @@ describe('UtilsController', () => {
         });
 
         it('should throw the "SDKUnauthorizedError" exception', async () => {
+
             mockFetch.mockResolvedValue({
                 ok: false,
                 status: 401,


### PR DESCRIPTION
This PR

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

- [WRS-3102](https://chilipublishintranet.atlassian.net/browse/WRS-3102)

## Screenshots


[WRS-3102]: https://chilipublishintranet.atlassian.net/browse/WRS-3102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ