### PR TITLE
[Feature][WRS-3132] Expose global sleep in connector SDK types

### DIFF
--- a/packages/connectors/src/Connector.Global.ts
+++ b/packages/connectors/src/Connector.Global.ts
@@ -41,4 +41,12 @@ declare global {
     var ConnectorHttpError: ConnectorHttpErrorConstructor;
     var StudioFormData: StudioFormDataConstructor;
     var FilePointer: FilePointerConstructor;
+
+    /**
+     * Suspends execution for the given duration.
+     * Provided by the connector host runtime (e.g. Studio QuickJS / CLI debugger).
+     *
+     * @param ms - Duration to sleep in milliseconds.
+     */
+    function sleep(ms: number): Promise<void>;
 }


### PR DESCRIPTION
This PR
- Adds ambient `sleep(ms: number): Promise<void>` to connector global typings in `Connector.Global.ts`.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

- [WRS-3132](https://chilipublishintranet.atlassian.net/browse/WRS-3132)

## Screenshots

N/A (types-only change)

[WRS-3132]: https://chilipublishintranet.atlassian.net/browse/WRS-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ