### PR TITLE
:sparkles: [Feat][EDT-2503] Add method to get all layouts where frame…

### DIFF
--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -30,7 +30,7 @@ import {
     VerticalAlign,
 } from '../types/FrameTypes';
 import { GradientDeltaUpdate, GradientUpdate } from '../types/GradientStyleTypes';
-import { ShapeType, ShapeFrameSource } from '../types/ShapeTypes';
+import { ShapeFrameSource, ShapeType } from '../types/ShapeTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 import { ShapeController } from './ShapeController';
 
@@ -1305,6 +1305,17 @@ export class FrameController {
     setSmartCropSubjectId = async (id: Id, subjectId?: Id) => {
         const res = await this.#editorAPI;
         return res.setSmartCropSubjectId(id, subjectId).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will return the list of layouts (ids) where the specified frame is visible. This is done
+     * without executing any layout change actions.
+     * @param id The frame id to check for visibility in layouts
+     * @returns The list of layout ids where the frame is visible
+     */
+    getLayoutsWhereFrameIsVisible = async (id: Id) => {
+        const res = await this.#editorAPI;
+        return res.getLayoutsWhereFrameIsVisible(id).then((result) => getEditorResponseData<Id[]>(result));
     };
 }
 

--- a/packages/sdk/src/tests/controllers/FrameController.test.ts
+++ b/packages/sdk/src/tests/controllers/FrameController.test.ts
@@ -101,6 +101,7 @@ const mockedEditorApi: EditorAPI = {
     setFrameContainerShape: async () => getEditorResponseData(castToEditorResponse(null)),
     setFrameContainerProperties: async () => getEditorResponseData(castToEditorResponse(null)),
     setImageFrameSmartCropSettings: async () => getEditorResponseData(castToEditorResponse(null)),
+    getLayoutsWhereFrameIsVisible: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -172,6 +173,7 @@ beforeEach(() => {
     jest.spyOn(mockedEditorApi, 'setFrameContainerShape');
     jest.spyOn(mockedEditorApi, 'setFrameContainerProperties');
     jest.spyOn(mockedEditorApi, 'setImageFrameSmartCropSettings');
+    jest.spyOn(mockedEditorApi, 'getLayoutsWhereFrameIsVisible');
 
     id = mockSelectFrame.id;
 });
@@ -874,5 +876,11 @@ describe('Anchoring', () => {
         await mockedFrameController.setFrameContainerShape(id, shapeFrameSource);
         expect(mockedEditorApi.setFrameContainerShape).toHaveBeenCalledTimes(1);
         expect(mockedEditorApi.setFrameContainerShape).toHaveBeenCalledWith(id, JSON.stringify(shapeFrameSource));
+    });
+
+    it('should be possible to get layouts where frame is visible', async () => {
+        await mockedFrameController.getLayoutsWhereFrameIsVisible(id);
+        expect(mockedEditorApi.getLayoutsWhereFrameIsVisible).toHaveBeenCalledTimes(1);
+        expect(mockedEditorApi.getLayoutsWhereFrameIsVisible).toHaveBeenCalledWith(id);
     });
 });


### PR DESCRIPTION
… is visible

This PR

## PR Guidelines

- [X] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

<!-- Prefer a JIRA ticket link when one exists (required by check-description).
     If there is no JIRA ticket (e.g. only a GitHub issue, or none), add the
     `No JIRA ticket` label. You may still link a GitHub issue below. -->

- [EDT-2503](https://chilipublishintranet.atlassian.net/browse/EDT-2503)

## Screenshots


[EDT-2503]: https://chilipublishintranet.atlassian.net/browse/EDT-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ