### PR TITLE
[Feature][EDT-2515] Expose custom shape type and path (get/set) in SDK

### DIFF
--- a/packages/sdk/src/controllers/FrameController.ts
+++ b/packages/sdk/src/controllers/FrameController.ts
@@ -753,7 +753,12 @@ export class FrameController {
     };
 
     /**
-     * This method will set the container shape of a specified frame
+     * This method will set the container shape of a specified frame (the mask/crop shape a
+     * frame, e.g. an image frame, is clipped to).
+     *
+     * This is the counterpart of {@link ShapeController.setShapeFrameSource}, which sets the
+     * geometry of a shape frame's own source instead of a frame's container. Both accept the
+     * same {@link ShapeFrameSource} shape.
      * @param frameId the id of the frame that needs to get updated
      * @param value the shape frame source object
      * @returns

--- a/packages/sdk/src/controllers/ShapeController.ts
+++ b/packages/sdk/src/controllers/ShapeController.ts
@@ -1,6 +1,6 @@
 import { EditorAPI, Id } from '../types/CommonTypes';
 import { ColorUsage } from '../types/ColorStyleTypes';
-import { CornerRadiusUpdateModel, ShapeProperties } from '../types/ShapeTypes';
+import { CornerRadiusUpdateModel, ShapeFrameSource, ShapeProperties } from '../types/ShapeTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 
 /**
@@ -163,5 +163,25 @@ export class ShapeController {
     setRadiusBottomRight = async (id: Id, radius: number) => {
         const cornerRadius: CornerRadiusUpdateModel = { bottomRight: radius };
         return this.setShapeCorners(id, cornerRadius);
+    };
+
+    /**
+     * This method sets the shape source (geometry) of a shape frame, e.g. its type
+     * (`rectangle`, `ellipse`, `polygon` or `custom`), corner radius, polygon side count or,
+     * for a `custom` shape, its path. Note that the `path` of a `custom` shape is expressed
+     * in coordinates relative to the frame (`0` to `1`), not absolute units.
+     *
+     * This is the counterpart of {@link FrameController.setFrameContainerShape}, which sets
+     * the mask/crop shape of an image frame's container instead of a shape frame's own
+     * geometry. Both accept the same {@link ShapeFrameSource} shape.
+     * @param id the id of the shapeFrame that needs to get updated.
+     * @param source the new shape source to set on the shape frame.
+     * @returns
+     */
+    setShapeFrameSource = async (id: Id, source: ShapeFrameSource) => {
+        const res = await this.#editorAPI;
+        return res
+            .setShapeFrameSource(id, JSON.stringify(source))
+            .then((result) => getEditorResponseData<null>(result));
     };
 }

--- a/packages/sdk/src/tests/controllers/ShapeController.test.ts
+++ b/packages/sdk/src/tests/controllers/ShapeController.test.ts
@@ -3,7 +3,7 @@ import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorR
 import { mockSelectFrame } from '../__mocks__/FrameProperties';
 import { ShapeController } from '../../controllers/ShapeController';
 import { ColorType, ColorUsageType } from '../../types/ColorStyleTypes';
-import { CornerRadiusUpdateModel } from '../../types/ShapeTypes';
+import { CornerRadiusUpdateModel, ShapeFrameSource, ShapeType } from '../../types/ShapeTypes';
 
 let id: Id;
 
@@ -12,12 +12,14 @@ let mockedShapeController: ShapeController;
 const mockedEditorApi: EditorAPI = {
     setShapeProperties: async () => getEditorResponseData(castToEditorResponse(null)),
     setShapeCorners: async () => getEditorResponseData(castToEditorResponse(null)),
+    setShapeFrameSource: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
     mockedShapeController = new ShapeController(mockedEditorApi);
     jest.spyOn(mockedEditorApi, 'setShapeProperties');
     jest.spyOn(mockedEditorApi, 'setShapeCorners');
+    jest.spyOn(mockedEditorApi, 'setShapeFrameSource');
 
     id = mockSelectFrame.id;
 });
@@ -95,6 +97,20 @@ describe('ShapeController', () => {
             await mockedShapeController.setRadiusBottomRight(id, radius.bottomRight ?? 5);
             expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledTimes(5);
             expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledWith(id, JSON.stringify(radius));
+        });
+    });
+    describe('setShapeFrameSource', () => {
+        it('Should be possible to set a rectangle shape source', async () => {
+            const source: ShapeFrameSource = { type: ShapeType.rectangle };
+            await mockedShapeController.setShapeFrameSource(id, source);
+            expect(mockedEditorApi.setShapeFrameSource).toHaveBeenCalledTimes(1);
+            expect(mockedEditorApi.setShapeFrameSource).toHaveBeenCalledWith(id, JSON.stringify(source));
+        });
+        it('Should be possible to set a custom shape source with a path', async () => {
+            const source: ShapeFrameSource = { type: ShapeType.custom, path: 'M0 0 L1 0 L1 1 Z' };
+            await mockedShapeController.setShapeFrameSource(id, source);
+            expect(mockedEditorApi.setShapeFrameSource).toHaveBeenCalledTimes(2);
+            expect(mockedEditorApi.setShapeFrameSource).toHaveBeenCalledWith(id, JSON.stringify(source));
         });
     });
 });

--- a/packages/sdk/src/types/FrameTypes.ts
+++ b/packages/sdk/src/types/FrameTypes.ts
@@ -110,8 +110,13 @@ export type ShapeFrame = {
     };
     src: {
         type: ShapeType;
-        cornerRadius: CornerRadiusNone | CornerRadiusAll | CornerRadiusOnly;
+        // present for `rectangle` and `polygon`, absent for `ellipse` and `custom`
+        cornerRadius?: CornerRadiusNone | CornerRadiusAll | CornerRadiusOnly;
+        // present for `polygon` only
         sides?: number;
+        // present for `custom` only; an SVG-style path string (`M`/`L`/`C`/`Z` commands only)
+        // in coordinates relative to the frame (`0` to `1`), not absolute units
+        path?: string;
     };
     dropShadowSettings?: DropShadowSettings;
     gradient?: GradientUsage;


### PR DESCRIPTION
Adds ShapeController.setShapeFrameSource, the SDK counterpart to the engine's new setShapeFrameSource API method, letting SDK consumers set the geometry (including a custom path) of a shape frame's own source - mirroring the existing FrameController.setFrameContainerShape for an image frame's mask.

Also fixes the ShapeFrame.src type in FrameTypes.ts, which was missing the `path` field entirely (and incorrectly typed `cornerRadius` as required for all shape types), so getters (getFrameByName, getFrames, ...) now correctly type a custom shape's path.

This PR

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets


- [EDT-2515](https://chilipublishintranet.atlassian.net/browse/EDT-2515)

## Screenshots


[EDT-2515]: https://chilipublishintranet.atlassian.net/browse/EDT-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ