### PR TITLE
[EDT-2554] Removed setListVariableAvailableItems and getListVariableAvailableItems

### DIFF
--- a/packages/actions/src/ActionHelpers.ts
+++ b/packages/actions/src/ActionHelpers.ts
@@ -320,44 +320,6 @@ function setSelectedItemFromListVariable(variableName: string | Variable, item: 
 }
 
 /**
- * Set the available items in a list variable. Setting these values filters the items that can be selected in the list variable.
- * When set to null, all items are available for selection.
- *
- * @param {string | Variable} variableName - The name of the list variable or a variable object.
- * @param availableItems The array of available items to set, or `null` to allow all items.
- */
-function setListVariableAvailableItems(variableName: string | Variable, availableItems: string[] | null) {
-    const list = studio.variables.byName(variableName);
-    if (list.type !== 'list') {
-        throw new Error('Expected a list variable but got one of type ' + list.type);
-    }
-
-    if (
-        availableItems !== null &&
-        (!Array.isArray(availableItems) || availableItems.some((item) => typeof item !== 'string'))
-    ) {
-        throw new Error('Expected null or an array of strings');
-    }
-
-    list.setAvailableItems(availableItems);
-}
-
-/**
- * Gets the list of items currently available for selection in a list variable.
- * If the available items have not been set, this will return all items in the list variable.
- *
- * @param {string | Variable} variableName - The name of the list variable or a variable object.
- * @returns The available items in the list variable.
- */
-function getListVariableAvailableItems(variableName: string | Variable): string[] {
-    const list = studio.variables.byName(variableName);
-    if (list.type !== 'list') {
-        throw new Error('Expected a list variable but got one of type ' + list.type);
-    }
-    return list.availableItems;
-}
-
-/**
  * Set the prefix of the variable.
  *
  * @param variableName The name of the variable or a variable object.

--- a/packages/actions/types/Actions.d.ts
+++ b/packages/actions/types/Actions.d.ts
@@ -299,13 +299,6 @@ declare module 'grafx-studio-actions' {
              * @param suffix the suffix to set
              */
             setSuffix(suffix: string | null): void;
-
-            /**
-             * Sets the available items for a list variable
-             *
-             * @param availableItems the list of available items. Set to null to allow all available items
-             */
-            setAvailableItems(availableItems: string[] | null): void;
         }
 
         /**
@@ -367,19 +360,7 @@ declare module 'grafx-studio-actions' {
          * - "sv"
          */
         export type Language =
-            | 'en_US'
-            | 'cs'
-            | 'da'
-            | 'nl'
-            | 'fi'
-            | 'fr'
-            | 'de'
-            | 'it'
-            | 'no'
-            | 'pl'
-            | 'pt_PT'
-            | 'es_ES'
-            | 'sv';
+            'en_US' | 'cs' | 'da' | 'nl' | 'fi' | 'fr' | 'de' | 'it' | 'no' | 'pl' | 'pt_PT' | 'es_ES' | 'sv';
 
         /**
          * The different values a Variable can have depending on the Variable Type.
@@ -468,11 +449,6 @@ declare module 'grafx-studio-actions' {
             readonly type: VariableType.list;
             readonly items: string[];
             readonly selected: string | null;
-            /**
-             * The items that are currently available for selection in the dropdown.
-             * If not set, all items in `items` are considered available and returned.
-             */
-            readonly availableItems: string[];
         }
 
         /**
@@ -711,22 +687,6 @@ declare module 'grafx-studio-actions' {
              * Gets the date value of a variable
              */
             getDateValue(name: string | Variable): Date | null;
-
-            /**
-             * Gets the available items for a list variable.
-             * Note: If no filter has been set via setListVariableAvailableItems, this will return all items in the list variable
-             *
-             * @param name the variable name
-             * @returns the list of available items.
-             */
-            getListVariableAvailableItems(name: string | Variable): string[];
-
-            /**
-             * Sets the available items for a list variable
-             * @param name the variable name
-             * @param availableItems the list of available items. Set to null to allow all available items
-             */
-            setListVariableAvailableItems(name: string | Variable, availableItems: string[] | null): void;
 
             /**
              * Set the readonly state of a variable

--- a/packages/actions/types/Actions.d.ts
+++ b/packages/actions/types/Actions.d.ts
@@ -360,7 +360,19 @@ declare module 'grafx-studio-actions' {
          * - "sv"
          */
         export type Language =
-            'en_US' | 'cs' | 'da' | 'nl' | 'fi' | 'fr' | 'de' | 'it' | 'no' | 'pl' | 'pt_PT' | 'es_ES' | 'sv';
+            | 'en_US'
+            | 'cs'
+            | 'da'
+            | 'nl'
+            | 'fi'
+            | 'fr'
+            | 'de'
+            | 'it'
+            | 'no'
+            | 'pl'
+            | 'pt_PT'
+            | 'es_ES'
+            | 'sv';
 
         /**
          * The different values a Variable can have depending on the Variable Type.

--- a/packages/sdk/src/next/types/VariableTypes.ts
+++ b/packages/sdk/src/next/types/VariableTypes.ts
@@ -3,7 +3,6 @@ import { ListVariableItem, ValueWithStyle, Variable } from '../../types/Variable
 export interface ListVariable extends Variable {
     items: ListVariableItem[];
     removeParagraphIfEmpty: boolean;
-    availableItems: string[];
     selected?: ListVariableItem;
     prefix?: ValueWithStyle;
     suffix?: ValueWithStyle;

--- a/packages/sdk/src/types/VariableTypes.ts
+++ b/packages/sdk/src/types/VariableTypes.ts
@@ -77,7 +77,6 @@ export interface ListVariable extends Variable {
     selected?: string;
     prefix?: ValueWithStyle;
     suffix?: ValueWithStyle;
-    availableItems: string[];
 }
 
 export interface BooleanVariable extends Variable {


### PR DESCRIPTION
This PR removed setListVariableAvailableItems and getListVariableAvailableItems methods and availableItems property.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

<!-- Prefer a JIRA ticket link when one exists (required by check-description).
     If there is no JIRA ticket (e.g. only a GitHub issue, or none), add the
     `No JIRA ticket` label. You may still link a GitHub issue below. -->

- [EDT-2554](https://chilipublishintranet.atlassian.net/browse/EDT-2554)

## Screenshots


[EDT-2554]: https://chilipublishintranet.atlassian.net/browse/EDT-2554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ