### PR TITLE
[GRAFX-6598] Make Dependabot GitHub Actions PRs mergeable without exposing secrets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
-  # github-actions scope only: a `uses:` bump can't touch code, tests or the
-  # build, so pr-build.yml skips its build job for dependabot[bot]. Adding an
-  # npm/yarn ecosystem here means removing that skip first.
+  # github-actions scope only. These PRs run the full build/test; only the
+  # secret-backed steps (Sonar, Azure, PR comment) skip for the dependabot[bot] actor.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
+  # github-actions scope only: a `uses:` bump can't touch code, tests or the
+  # build, so pr-build.yml skips its build job for dependabot[bot]. Adding an
+  # npm/yarn ecosystem here means removing that skip first.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - "No JIRA ticket"
+      - "Skip QA"

--- a/.github/workflows/check-description.yml
+++ b/.github/workflows/check-description.yml
@@ -1,20 +1,23 @@
 name: Check PR description for JIRA ticket
 on:
-    pull_request:
-        types: [opened, edited, labeled, unlabeled, reopened]
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, reopened]
 permissions:
-    contents: read
+  contents: read
 jobs:
-    check-description:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Check description of the Pull Request
-              if: ${{ !contains(github.event.pull_request.labels.*.name, 'No JIRA ticket') }}
-              uses: actions/github-script@v9
-              with:
-                  script: |
-                      const body = context.payload.pull_request.body ?? '';
-                      const jiraPattern = /(?:https:\/\/[\w.-]+\.atlassian\.net\/browse\/[A-Z][A-Z0-9]+-\d+|[A-Z][A-Z0-9]+-\d+)/i;
-                      if (!jiraPattern.test(body)) {
-                          core.setFailed('PR description must contain a JIRA ticket link or key (e.g. GRAFX-1234). Add the `No JIRA ticket` label to skip.');
-                      }
+  check-description:
+    # Dependabot github-actions PRs are auto-labeled `No JIRA ticket`; skip the
+    # check outright so a label-timing race on `opened` cannot fail the PR.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check description of the Pull Request
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'No JIRA ticket') }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const jiraPattern = /(?:https:\/\/[\w.-]+\.atlassian\.net\/browse\/[A-Z][A-Z0-9]+-\d+|[A-Z][A-Z0-9]+-\d+)/i;
+            if (!jiraPattern.test(body)) {
+                core.setFailed('PR description must contain a JIRA ticket link or key (e.g. GRAFX-1234). Add the `No JIRA ticket` label to skip.');
+            }

--- a/.github/workflows/check-description.yml
+++ b/.github/workflows/check-description.yml
@@ -6,9 +6,6 @@ permissions:
   contents: read
 jobs:
   check-description:
-    # Dependabot github-actions PRs are auto-labeled `No JIRA ticket`; skip the
-    # check outright so a label-timing race on `opened` cannot fail the PR.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check description of the Pull Request

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,8 +13,11 @@ permissions:
   contents: read
   actions: read
   packages: read
+# The single `build` job also deploys (SonarQube, Azure) with secrets a Dependabot
+# PR does not get, so it is skipped for `dependabot[bot]`
 jobs:
   build:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: build (18)
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -47,12 +47,10 @@ jobs:
       - name: Publish Unit Test Results
         continue-on-error: true
         uses: EnricoMi/publish-unit-test-result-action@b9f6c61d965bcaa18acc02d6daf706373a448f02 # v1
-        # needs write GITHUB_TOKEN — skipped on Dependabot PRs
         if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           files: packages/sdk/coverage/**/*.xml
       - name: SonarQube analysis
-        # needs SONAR_TOKEN — skipped on Dependabot PRs
         if: github.actor != 'dependabot[bot]'
         uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
@@ -72,7 +70,6 @@ jobs:
         run: |
           cp -R packages/sdk/_bundles packages/sdk/upload/dev-packages/${{ github.event.pull_request.number }}
       - name: Azure Login
-        # needs the CICD service-principal secret — skipped on Dependabot PRs
         if: github.actor != 'dependabot[bot]'
         uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,11 +13,8 @@ permissions:
   contents: read
   actions: read
   packages: read
-# The single `build` job also deploys (SonarQube, Azure) with secrets a Dependabot
-# PR does not get, so it is skipped for `dependabot[bot]`
 jobs:
   build:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: build (18)
     steps:
@@ -50,10 +47,13 @@ jobs:
       - name: Publish Unit Test Results
         continue-on-error: true
         uses: EnricoMi/publish-unit-test-result-action@b9f6c61d965bcaa18acc02d6daf706373a448f02 # v1
-        if: always()
+        # needs write GITHUB_TOKEN — skipped on Dependabot PRs
+        if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           files: packages/sdk/coverage/**/*.xml
       - name: SonarQube analysis
+        # needs SONAR_TOKEN — skipped on Dependabot PRs
+        if: github.actor != 'dependabot[bot]'
         uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +72,8 @@ jobs:
         run: |
           cp -R packages/sdk/_bundles packages/sdk/upload/dev-packages/${{ github.event.pull_request.number }}
       - name: Azure Login
+        # needs the CICD service-principal secret — skipped on Dependabot PRs
+        if: github.actor != 'dependabot[bot]'
         uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: >-
@@ -82,6 +84,7 @@ jobs:
               "subscriptionId": "${{ vars.AZ_SUBSCRIPTION_ID_SAAS_DEV }}"
             }
       - name: Copy to Azure Blob Storage
+        if: github.actor != 'dependabot[bot]'
         uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
@@ -92,6 +95,7 @@ jobs:
               --overwrite true \
               --auth-mode login
       - name: Copy to Azure Blob Storage (Connectors)
+        if: github.actor != 'dependabot[bot]'
         uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |
@@ -105,6 +109,7 @@ jobs:
         run: |
           node cicd.js actions node scripts/prepare-release.mjs
       - name: Copy to Azure Blob Storage (Actions)
+        if: github.actor != 'dependabot[bot]'
         uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
         with:
           inlineScript: |

--- a/.github/workflows/pr-comment-on-open.yml
+++ b/.github/workflows/pr-comment-on-open.yml
@@ -4,6 +4,9 @@ on:
     types: [opened]
 jobs:
   comment:
+    # Skip for Dependabot: its PR runs get a read-only token, so createComment
+    # fails. This is a courtesy comment, not a check.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr-comment-on-open.yml
+++ b/.github/workflows/pr-comment-on-open.yml
@@ -9,7 +9,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: "Comment on PR"
         uses: actions/github-script@v9
-        # Skip for Dependabot: its PR runs get a read-only token, so createComment fails.
         if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-comment-on-open.yml
+++ b/.github/workflows/pr-comment-on-open.yml
@@ -4,15 +4,13 @@ on:
     types: [opened]
 jobs:
   comment:
-    # Skip for Dependabot: its PR runs get a read-only token, so createComment
-    # fails. This is a courtesy comment, not a check.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - name: "Comment on PR"
         uses: actions/github-script@v9
-        if: github.event_name == 'pull_request'
+        # Skip for Dependabot: its PR runs get a read-only token, so createComment fails.
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,9 @@ Prefer a JIRA ticket link in the PR description when one exists (enforced by CI 
 
 ## Dependabot
 
-Dependabot `github-actions` PRs are auto-labeled `No JIRA ticket` and `Skip QA`. They run the full install / lint / test / build (the FontAwesome token is in the Dependabot secrets store); only the steps that are skipped are secret-backed steps that Dependabot does not have (SonarQube, Azure, Playwright integration secrets).
+Dependabot `github-actions` PRs are auto-labeled `No JIRA ticket` and `Skip QA`. They run the full install / lint / test / build. The SonarQube analysis, the Azure uploads and the PR comment are skipped on the bot's own runs, so a bump that only affects one of those is not exercised there.
 
-Because those steps are skipped on the bot's own runs, a bump that only touches one of them is not exercised there. **Do not enable auto-merge for these PRs and do not merge one without a human review** — check the publisher, the pinned SHA and the changelog. The next human PR or the merge-to-`main` build is what actually exercises the new action version; revert the bump if that build fails.
+**Do not enable auto-merge for these PRs and do not merge one without a human review** — check the publisher, the pinned SHA and the changelog. The next human PR or the merge-to-`main` build is what actually exercises the new action version; revert the bump if that build fails.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,9 @@ Prefer a JIRA ticket link in the PR description when one exists (enforced by CI 
 
 ## Dependabot
 
-Dependabot `github-actions` PRs are auto-labeled `No JIRA ticket` and `Skip QA`, and the `build` job is skipped on them (Dependabot PRs run without the deploy secrets). Review them as pin bumps — check the publisher, the pinned SHA and the changelog — not as CI-certified changes. The next human PR or the merge-to-`main` build is the real integration test; revert the bump if that build fails.
+Dependabot `github-actions` PRs are auto-labeled `No JIRA ticket` and `Skip QA`. They run the full install / lint / test / build (the FontAwesome token is in the Dependabot secrets store); only the steps that are skipped are secret-backed steps that Dependabot does not have (SonarQube, Azure, Playwright integration secrets).
 
-Because `build` is skipped, **do not enable auto-merge for these PRs and do not merge one without a human review**. A person must confirm the pin bump, then click merge.
+Because those steps are skipped on the bot's own runs, a bump that only touches one of them is not exercised there. **Do not enable auto-merge for these PRs and do not merge one without a human review** — check the publisher, the pinned SHA and the changelog. The next human PR or the merge-to-`main` build is what actually exercises the new action version; revert the bump if that build fails.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ This section provides a step-by-step guide on how to set up this project for loc
 
 Before you begin, ensure you have the following software installed on your local machine:
 
-* Node.js: This is the runtime environment that will allow you to execute the project. You can download it from [here](https://nodejs.org/).
-* Yarn: This is the package manager we use for managing project dependencies. If you haven't installed Yarn already, you can do so globally by running the following command in your terminal:
+- Node.js: This is the runtime environment that will allow you to execute the project. You can download it from [here](https://nodejs.org/).
+- Yarn: This is the package manager we use for managing project dependencies. If you haven't installed Yarn already, you can do so globally by running the following command in your terminal:
 
 ```bash
 npm install -g yarn
@@ -46,26 +46,32 @@ We hope these instructions make your setup process smooth and straightforward. H
 
 \*replace my-branch-name with something specific. We use the prefixes fix and feature in our branches to indicate what they represent. An example for a branch that fixes a bug in playAnimation f.e. could be `fix/play-animation-fixdescription`
 
-\*\*Pull request titles determine the automatic version behavior. Please use the following diagram to determine the correct title prefix: 
+\*\*Pull request titles determine the automatic version behavior. Please use the following diagram to determine the correct title prefix:
 ![Title Prefix Flow](images/pr_flow.svg)
 
 ## Acceptance criteria
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
--   Write tests.
--   Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, submit them as separate pull requests.
--   Write [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
--   Prefix the title with [Fix] or [Feature] to describe what the scope is
+- Write tests.
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, submit them as separate pull requests.
+- Write [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Prefix the title with [Fix] or [Feature] to describe what the scope is
 
 ## Related tickets
 
 Prefer a JIRA ticket link in the PR description when one exists (enforced by CI unless the PR has the `No JIRA ticket` label). Related tickets may also link a **GitHub issue**. The `No JIRA ticket` label means there is no JIRA ticket (skip the JIRA check); it does not mean there is no ticket of any kind.
 
+## Dependabot
+
+Dependabot `github-actions` PRs are auto-labeled `No JIRA ticket` and `Skip QA`, and the `build` job is skipped on them (Dependabot PRs run without the deploy secrets). Review them as pin bumps — check the publisher, the pinned SHA and the changelog — not as CI-certified changes. The next human PR or the merge-to-`main` build is the real integration test; revert the bump if that build fails.
+
+Because `build` is skipped, **do not enable auto-merge for these PRs and do not merge one without a human review**. A person must confirm the pin bump, then click merge.
+
 ## Resources
 
--   [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
--   [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
--   [GitHub Help](https://help.github.com/)
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com/)
 
 AI coding agents: see [AGENTS.md](AGENTS.md) for agent-specific workflow rules and coding conventions.


### PR DESCRIPTION
This PR

## PR Guidelines

- [ ] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

<!-- Prefer a JIRA ticket link when one exists (required by check-description).
     If there is no JIRA ticket (e.g. only a GitHub issue, or none), add the
     `No JIRA ticket` label. You may still link a GitHub issue below. -->

- [GRAFX-6598](https://chilipublishintranet.atlassian.net/browse/GRAFX-6598)

## Screenshots


[GRAFX-6598]: https://chilipublishintranet.atlassian.net/browse/GRAFX-6598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ