### PR TITLE
[Fix] Add new UnconfiguredInjectedDataSourceDocumentIssue

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -155,6 +155,7 @@ export type {
     DocumentIssue,
     FontLoadingDocumentIssue,
     OverflowDocumentIssue,
+    UnconfiguredInjectedDataSourceDocumentIssue,
 } from './types/DocumentTypes';
 
 export type {

--- a/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
+++ b/packages/sdk/src/tests/controllers/SubscriberContoller.test.ts
@@ -588,6 +588,11 @@ describe('SubscriberController', () => {
     it('should be possible to subscribe to onDocumentIssueListChanged', async () => {
         const documentIssues: DocumentIssue[] = [
             { fontId: 'fontId', name: 'fontName', type: DocumentIssueTypeEnum.fontLoading },
+            {
+                frameId: 'frameId',
+                variableId: 'variableId',
+                type: DocumentIssueTypeEnum.unconfiguredInjectedDataSource,
+            },
         ];
         await mockedSubscriberController.onDocumentIssueListChanged(JSON.stringify(documentIssues));
 

--- a/packages/sdk/src/types/DocumentTypes.ts
+++ b/packages/sdk/src/types/DocumentTypes.ts
@@ -18,6 +18,7 @@ export enum DocumentIssueTypeEnum {
     actionRegister = 'actionRegister',
     actionExecution = 'actionExecution',
     actionCircular = 'actionCircular',
+    unconfiguredInjectedDataSource = 'unconfiguredInjectedDataSource',
 }
 
 export type OverflowDocumentIssue = {
@@ -46,12 +47,19 @@ export type ActionCircularDocumentIssue = {
     type: DocumentIssueTypeEnum.actionCircular;
 };
 
+export type UnconfiguredInjectedDataSourceDocumentIssue = {
+    frameId: Id;
+    variableId: Id;
+    type: DocumentIssueTypeEnum.unconfiguredInjectedDataSource;
+};
+
 export type DocumentIssue =
     | OverflowDocumentIssue
     | FontLoadingDocumentIssue
     | ActionExecutionDocumentIssue
     | ActionRegisterDocumentIssue
-    | ActionCircularDocumentIssue;
+    | ActionCircularDocumentIssue
+    | UnconfiguredInjectedDataSourceDocumentIssue;
 
 export type UndoState = {
     canUndo: boolean;


### PR DESCRIPTION
This PR adds a new UnconfiguredInjectedDataSourceDocumentIssue that is triggered if data or model is not yet configured (only for injected DSV). A WRS ticket will be created.

## PR Guidelines

- [x] I have read the [contribution and PR guidelines](/chili-publish/studio-sdk/blob/main/CONTRIBUTING.md)

## Related tickets

https://chilipublishintranet.atlassian.net/browse/EDT-2547